### PR TITLE
add new URL to CSRF trusted origins

### DIFF
--- a/apis_ontology/settings/server_settings.py
+++ b/apis_ontology/settings/server_settings.py
@@ -8,7 +8,7 @@ APIS_BASE_URI = "https://tibschol.acdh-ch.oeaw.ac.at/"
 ROOT_URLCONF = "apis_ontology.urls"
 CSRF_TRUSTED_ORIGINS = [
     "https://tibschol.acdh-ch.oeaw.ac.at",
-    "https://tibschol-test.acdh-ch-dev.oeaw.ac.at",
+    "https://tibschol.acdh-ch-dev.oeaw.ac.at",
 ]
 
 INSTALLED_APPS += [


### PR DESCRIPTION
* [`apis_ontology/settings/server_settings.py`](diffhunk://#diff-2903b7820ed1f17f3d8fa1eee95d7bba39d40c18f6810445aa4f3fdfa84636baL11-R11): Changed the URL for the CSRF trusted origin from `https://tibschol-test.acdh-ch-dev.oeaw.ac.at` to `https://tibschol.acdh-ch-dev.oeaw.ac.at`.

closes #151 