### PR TITLE
ci(deps): bump prosnet-workflows to 0.4.6

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,5 +11,5 @@ on:
 
 jobs:
   deploy:
-    uses: acdh-oeaw/prosnet-workflows/.github/workflows/deploy-apis-instance.yml@v0.4.5
+    uses: acdh-oeaw/prosnet-workflows/.github/workflows/deploy-apis-instance.yml@v0.4.6
     secrets: inherit


### PR DESCRIPTION
0.4.6 contains fix that installs graphviz in container for documentation app to work