### PR TITLE
Add important to overriding tibschol styles

### DIFF
--- a/apis_ontology/static/styles/tibschol.css
+++ b/apis_ontology/static/styles/tibschol.css
@@ -52,7 +52,7 @@ body {
 
 
 textarea.form-control{
-    height: 5em;
+    height: 5em !important;
 }
 
 


### PR DESCRIPTION
This pull request includes a minor change to the `apis_ontology/static/styles/tibschol.css` file. The change enforces the height of the `textarea.form-control` element using the `!important` flag.

* [`apis_ontology/static/styles/tibschol.css`](diffhunk://#diff-8b51716e1c7ad327090d05e71a05442884713f6eb743d9fd4bf90a9173a23cb9L55-R55): Added `!important` to the height property of the `textarea.form-control` element to ensure the specified height is applied.