### PR TITLE
fix: use RelationsFilterSet instead of GenericFilterSet

### DIFF
--- a/apis_ontology/filtersets.py
+++ b/apis_ontology/filtersets.py
@@ -5,6 +5,7 @@ from apis_core.apis_entities.filtersets import (
 )
 from apis_core.apis_entities.models import RootObject
 from apis_core.generic.filtersets import GenericFilterSet
+from apis_core.relations.filtersets import RelationFilterSet
 from apis_core.relations.models import Relation
 from django.apps import apps
 from django.db import models
@@ -12,8 +13,6 @@ from django.db import models
 from apis_ontology.forms import (
     PersonSearchForm,
     PlaceSearchForm,
-    TibScholRelationMixinForm,
-    TibScholRelationMixinSearchForm,
     WorkSearchForm,
 )
 from apis_ontology.models import Instance, Person, Place, Work
@@ -93,10 +92,9 @@ class LegacyStuffMixinFilterSet(AbstractEntityFilterSet):
         }
 
 
-class TibScholRelationMixinFilterSet(GenericFilterSet):
-    class Meta(GenericFilterSet.Meta):
-        form = TibScholRelationMixinSearchForm
-        exclude = ABSTRACT_ENTITY_FILTERS_EXCLUDE
+class TibScholRelationMixinFilterSet(RelationFilterSet):
+    class Meta(RelationFilterSet.Meta):
+        exclude = RelationFilterSet.Meta.exclude + ABSTRACT_ENTITY_FILTERS_EXCLUDE
         filter_overrides = {
             models.CharField: {
                 "filter_class": django_filters.CharFilter,


### PR DESCRIPTION
This pull request includes changes to the `apis_ontology/filtersets.py` file to update the filter sets used in the project. The most important changes include importing the `RelationFilterSet` and modifying the `TibScholRelationMixinFilterSet` class to inherit from it instead of `GenericFilterSet`.

Updates to filter sets:

* [`apis_ontology/filtersets.py`](diffhunk://#diff-5ac6e616e544d2b287f3183cf24bcad8eebf668eca1b421cbcad54870356ed59R8-L16): Added import statement for `RelationFilterSet` from `apis_core.relations.filtersets`.
* [`apis_ontology/filtersets.py`](diffhunk://#diff-5ac6e616e544d2b287f3183cf24bcad8eebf668eca1b421cbcad54870356ed59L96-R97): Modified the `TibScholRelationMixinFilterSet` class to inherit from `RelationFilterSet` instead of `GenericFilterSet`, and updated its `Meta` class to exclude additional fields.