### PR TITLE
use uri property instead of constructing uris

### DIFF
--- a/apis_ontology/tables.py
+++ b/apis_ontology/tables.py
@@ -90,7 +90,7 @@ class WorkTable(TibscholEntityMixinTable):
         context = {
             "entity_id": record.author_id,
             "entity_name": record.author_name,
-            "entity_uri": f"/apis/apis_ontology.person/{record.author_id}",  # TODO: use urls
+            "entity_uri": Person.objects.get(pk=record.author_id).uri,
         }
         return mark_safe(
             render_to_string("apis_ontology/linked_entity_column.html", context)
@@ -121,7 +121,7 @@ class InstanceTable(TibscholEntityMixinTable):
         context = {
             "entity_id": record.author_id,
             "entity_name": record.author_name,
-            "entity_uri": f"/apis/apis_ontology.person/{record.author_id}",  # TODO: use urls
+            "entity_uri": Person.objects.get(pk=record.author_id).uri,
         }
         return mark_safe(
             render_to_string("apis_ontology/linked_entity_column.html", context)


### PR DESCRIPTION
This pull request includes changes to the `render_author` method in the `apis_ontology/tables.py` file to improve how entity URIs are generated. The most important changes are:

* [`apis_ontology/tables.py`](diffhunk://#diff-2ff430a2f96c033674f5795bd02c89280acef6d6b3e3d755ec2456e5e12b4b54L93-R93): Updated the `entity_uri` to fetch the URI directly from the `Person` object using its primary key, replacing the previous hardcoded URL format. This ensures that the correct and current URI is used for each author. [[1]](diffhunk://#diff-2ff430a2f96c033674f5795bd02c89280acef6d6b3e3d755ec2456e5e12b4b54L93-R93) [[2]](diffhunk://#diff-2ff430a2f96c033674f5795bd02c89280acef6d6b3e3d755ec2456e5e12b4b54L124-R124)