### PR TITLE
feat: show relations of nested places in Place detail page

### DIFF
--- a/apis_ontology/tables.py
+++ b/apis_ontology/tables.py
@@ -150,6 +150,12 @@ class RelationNameColumn(CustomTemplateColumn):
     orderable = False
 
 
+class RelationSubjectColumn(CustomTemplateColumn):
+    template_name = "columns/relation_subject.html"
+    verbose_name = "Subject"
+    orderable = False
+
+
 class RelationPredicateColumn(CustomTemplateColumn):
     template_name = "columns/relation_predicate.html"
     verbose_name = "Object"
@@ -222,6 +228,22 @@ class TibScholEntityMixinRelationsTable(GenericTable):
         ]
         exclude = ["desc"]
         per_page = 1000
+
+
+class PlaceRelationsTable(TibScholEntityMixinRelationsTable):
+    subject = RelationSubjectColumn()
+
+    class Meta(TibScholEntityMixinRelationsTable.Meta):
+        pass
+
+    field_order = [
+        "subject",
+        "relation",
+        "predicate",
+        "support_notes",
+        "zotero_refs",
+        "tei_refs",
+    ]
 
 
 class RelationsTable(TibScholEntityMixinRelationsTable):

--- a/apis_ontology/templates/apis_ontology/place_detail.html
+++ b/apis_ontology/templates/apis_ontology/place_detail.html
@@ -18,5 +18,5 @@
   </div>
 {% endblock %}
 {% block relations-include %}
-    {% include "relations/list_relations_include_tabs.html" %}
+{% include "relations/place_list_relations_include_tabs.html"  %}
 {% endblock relations-include %}

--- a/apis_ontology/templates/apis_ontology/place_form.html
+++ b/apis_ontology/templates/apis_ontology/place_form.html
@@ -1,5 +1,5 @@
 {% extends "apis_core/apis_entities/abstractentity_form.html" %}
 
 {% block relations-include %}
-{% include "relations/list_relations_include_tabs.html" with edit=True %}
+{% include "relations/place_list_relations_include_tabs.html" with edit=True %}
 {% endblock relations-include %}

--- a/apis_ontology/templates/columns/relation_subject.html
+++ b/apis_ontology/templates/columns/relation_subject.html
@@ -1,0 +1,9 @@
+{% if record.forward %}
+<a href="{{ record.subj.get_absolute_url }}" style="{{ highlight_style }}">
+    {{ record.subj }}
+</a>
+{% else %}
+<a href="{{ record.obj.get_absolute_url }}" style="{{ highlight_style }}">
+    {{ record.obj }}
+</a>
+{% endif %}

--- a/apis_ontology/templates/relations/place_list_relations_include_tabs.html
+++ b/apis_ontology/templates/relations/place_list_relations_include_tabs.html
@@ -1,0 +1,9 @@
+{% extends "relations/list_relations_include_tabs.html" %}
+
+{% load nested_relations %}
+
+
+{% block display-relations %}
+{% relations_from_place from_obj=object include_places_within=True as relations %}
+    {{ block.super }}
+{% endblock display-relations %}

--- a/apis_ontology/templatetags/nested_relations.py
+++ b/apis_ontology/templatetags/nested_relations.py
@@ -1,0 +1,48 @@
+import logging
+from django import template
+from django.utils.safestring import mark_safe
+from django.contrib.contenttypes.models import ContentType
+from apis_ontology.models import Place, PlaceIsLocatedWithinPlace
+from apis_core.relations.templatetags.relations import relations_from
+
+register = template.Library()
+
+logger = logging.getLogger(__name__)
+
+
+@register.simple_tag
+def relations_from_place(
+    from_obj, relation_type: ContentType = None, include_places_within=False
+):
+
+    def locations_contained_in(place_id):
+        try:
+            nested_places = [
+                rel.subj_object_id
+                for rel in set(
+                    (PlaceIsLocatedWithinPlace.objects.filter(obj_object_id=place_id))
+                )
+            ]
+            for p in nested_places:
+                nested_places.extend(locations_contained_in(p))
+        except Place.DoesNotExist:
+            pass
+        return nested_places
+
+    rels = relations_from(from_obj, relation_type)
+    if not include_places_within:
+        return rels
+
+    nested_locs = locations_contained_in(from_obj.pk)
+    if not nested_locs:
+        return rels
+
+    nested_rels = []
+    for nested_loc in nested_locs:
+        try:
+            nested_rels.extend(
+                relations_from(Place.objects.get(pk=nested_loc), relation_type)
+            )
+        except Place.DoesNotExist:
+            pass
+    return [*rels, *nested_rels]


### PR DESCRIPTION
This pull request introduces several changes to the `apis_ontology` module, primarily focusing on adding new columns and templates for handling place relations, as well as extending existing templates and tags to support nested relations.

Key changes include:

### New Columns and Templates:

* Added `RelationSubjectColumn` class to `apis_ontology/tables.py` for displaying subjects in the relations table.
* Created new template `relation_subject.html` to render subject links in the relations table.

### New Table Class:

* Introduced `PlaceRelationsTable` class in `apis_ontology/tables.py` to handle place-specific relations with a defined field order.

### Template Modifications:

* Updated `place_detail.html` and `place_form.html` to include the new `place_list_relations_include_tabs.html` template instead of the generic `list_relations_include_tabs.html`. [[1]](diffhunk://#diff-59692e5f5a8168abe9e2dc39b1fdb143b1ba653b1f974e8ebe12627305cef30eL4-R4) [[2]](diffhunk://#diff-7142606ed135e4f50a7903dd95180a43c12eda585af54ccac409b408e84cad24L4-R4)
* Added `place_list_relations_include_tabs.html` template to extend the base relations template and load nested relations.

### New Template Tag:

* Added `relations_from_place` template tag in `nested_relations.py` to fetch relations, including nested locations within a place.

closes #49