### PR TITLE
assign custom managers based on user permissions

### DIFF
--- a/apis_ontology/settings/server_settings.py
+++ b/apis_ontology/settings/server_settings.py
@@ -69,24 +69,11 @@ MIDDLEWARE += [
 
 
 def apis_view_passes_test(view) -> bool:
-    if view.request.user.is_authenticated:
-        return True
-    if view.permission_action_required == "view":
-        # this is set when APIS_DETAIL_VIEWS_ALLOWED is True
-        obj = view.get_object()
-        return obj.review
-    return False
-
-
-def apis_list_view_object_filter(view, queryset):
-    if view.request.user.is_authenticated:
-        return queryset
-
-    return queryset.filter(review=True)
+    # Temporary hack
+    return True
 
 
 APIS_LIST_VIEWS_ALLOWED = True
-APIS_LIST_VIEW_OBJECT_FILTER = apis_list_view_object_filter
 
 APIS_DETAIL_VIEWS_ALLOWED = True
 APIS_VIEW_PASSES_TEST = apis_view_passes_test


### PR DESCRIPTION
This pull request introduces changes to the `apis_ontology` module to implement user-based query filtering and simplify permission checks. The most significant changes include the introduction of a custom manager for authenticated user filtering, and the removal of detailed permission checks in the settings.

### User-based Query Filtering:

* [`apis_ontology/models.py`](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1R71-R80): Introduced `TibScholEntityManager` to filter querysets based on user authentication status using `get_current_user()` from the `crum` library.

### Manager Updates:

* [`apis_ontology/models.py`](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1R111-R112): Updated `Person`, `Work`, and `Instance` classes to use `TibScholEntityManager` for their `objects` attribute. [[1]](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1R111-R112) [[2]](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1R149-R150) [[3]](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1L154-R174) [[4]](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1L224-R248)

### Permission Checks Simplification:

* [`apis_ontology/settings/server_settings.py`](diffhunk://#diff-2903b7820ed1f17f3d8fa1eee95d7bba39d40c18f6810445aa4f3fdfa84636baL72-L89): Simplified the `apis_view_passes_test` function to always return `True` - which can be removed once https://github.com/acdh-oeaw/apis-core-rdf/issues/1400 is sorted.