### PR TITLE
develop a default custom template for tibschol for the detail panel

### DIFF
--- a/apis_ontology/templates/generic/partials/object_table.html
+++ b/apis_ontology/templates/generic/partials/object_table.html
@@ -1,0 +1,43 @@
+{% load apisgeneric %}
+{% load filter_utils %}
+{% load parse_comment %}
+{% load citation %}
+
+<table class="table table-hover">
+    {% modeldict object as d %}
+
+    {% for key, value in d.items %}
+    {% if not key|endswith:'.rootobject_ptr' %}
+    {% if value %}
+
+    <tr>
+        <th>
+            {{ key.verbose_name | title}}
+        </th>
+
+        <td>
+            {% if key|endswith:'.comments' %}
+            {{ value | parse_comment | safe}}
+            {% elif key|endswith:'.external_links' %}
+            {{ value | render_links | safe}}
+            {% elif key|endswith:'.longitude' %}
+            {{ value | render_coordinate}}
+            {% elif key|endswith:'.latitude' %}
+            {{ value | render_coordinate}}
+            {% elif key|endswith:'.zotero_ref' %}
+            {{ value | render_zotero_links | safe}}
+            {% else %}
+            {{ value | render_list_field}}
+            {% endif %}
+        </td>
+    </tr>
+    {% if key|endswith:'.pp_kdsb' %}
+    <tr>
+        <th> Citation</th>
+        <td>{{object|cite}}</td>
+    </tr>
+    {% endif %}
+    {% endif %}
+    {% endif %}
+    {% endfor %}
+</table>


### PR DESCRIPTION
This pull request introduces a new template for rendering an object table with various filters and utilities in the `apis_ontology` module. The key changes include loading necessary template tags, iterating over object dictionary items, and applying specific rendering filters based on key suffixes.

Template enhancements:

* [`apis_ontology/templates/generic/partials/object_table.html`](diffhunk://#diff-4ae29d46970c938241137ec6b2748aaa4132915768849e82f105e3cc981d24caR1-R43): Added template tags for `apisgeneric`, `filter_utils`, `parse_comment`, and `citation`. Iterated over object dictionary items and applied different rendering filters for keys ending with `.comments`, `.external_links`, `.longitude`, `.latitude`, and `.zotero_ref`. Included a citation row for keys ending with `.pp_kdsb`.