### PR TITLE
parse zoero links in item description

### DIFF
--- a/apis_ontology/templates/apis_ontology/instance_card_table.html
+++ b/apis_ontology/templates/apis_ontology/instance_card_table.html
@@ -97,7 +97,7 @@
     {% if object.item_description %}
     <tr>
         <th>Item description</th>
-        <td>{{ object.item_description | render_list_field }}</td>
+        <td>{{ object.item_description | parse_comment }}</td>
     </tr>
     {% endif %}
     {% if object.provenance %}


### PR DESCRIPTION
This pull request includes a change to the `apis_ontology/templates/apis_ontology/instance_card_table.html` file. The change modifies how the `item_description` field is rendered by using a different template filter.

Rendering changes:

* [`apis_ontology/templates/apis_ontology/instance_card_table.html`](diffhunk://#diff-ac015aadd4deade27789078ae6e3e6be12f2437a04134f49de32db677fbc65e7L100-R100): Changed the filter applied to `object.item_description` from `render_list_field` to `parse_comment`.