### PR TITLE
allow vertical resizing of text areas

### DIFF
--- a/apis_ontology/static/styles/tibschol.css
+++ b/apis_ontology/static/styles/tibschol.css
@@ -15,8 +15,9 @@ body {
 }
 
 
-textarea.form-control{
-    height: 5em !important;
+#content textarea.form-control{
+    height: 5em;
+    resize: vertical;
 }
 
 


### PR DESCRIPTION
This pull request includes a small change to the `apis_ontology/static/styles/tibschol.css` file. The change modifies the CSS selector for textareas within the `#content` element and adds the `resize: vertical` property.

Changes to CSS:

* [`apis_ontology/static/styles/tibschol.css`](diffhunk://#diff-8b51716e1c7ad327090d05e71a05442884713f6eb743d9fd4bf90a9173a23cb9L18-R20): Modified the `textarea.form-control` selector to `#content textarea.form-control` and added `resize: vertical` property.
 

closes #214