### PR TITLE
Enforce singular form of verbose name to plural for relations

### DIFF
--- a/apis_ontology/models.py
+++ b/apis_ontology/models.py
@@ -11,6 +11,7 @@ from apis_core.utils.helpers import create_object_from_uri
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.db.models import OuterRef, QuerySet, Subquery
+from django.db.models.signals import class_prepared
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from crum import get_current_user
@@ -387,6 +388,16 @@ class TibScholRelationMixin(VersionMixin, Relation, LegacyDateMixin, GenericMode
 
     class Meta:
         abstract = True
+
+
+def enforce_plural_name(sender, **kwargs):
+    if issubclass(sender, TibScholRelationMixin):
+        meta = sender._meta
+        # set verbose_name_plural to verbose_name
+        meta.verbose_name_plural = meta.verbose_name or sender.__name__.lower()
+
+
+class_prepared.connect(enforce_plural_name)
 
 
 class PersonActiveAtPlace(TibScholRelationMixin):


### PR DESCRIPTION
This pull request includes changes to the `apis_ontology/models.py` file to enforce plural names for certain Django models. The most important changes include importing the `class_prepared` signal and defining a new function to enforce plural names for models that subclass `TibScholRelationMixin`.

### Enforcing plural names for models:

* [`apis_ontology/models.py`](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1R14): Imported `class_prepared` from `django.db.models.signals` to use in the new function.
* [`apis_ontology/models.py`](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1R393-R402): Added the `enforce_plural_name` function to set `verbose_name_plural` to `verbose_name` or the model's name in lowercase for models subclassing `TibScholRelationMixin`. Connected this function to the `class_prepared` signal.

Adding an s suffix at the end does not make sense for plural names of relation models.

closes #225