### PR TITLE
Supply default order

### DIFF
--- a/apis_ontology/models.py
+++ b/apis_ontology/models.py
@@ -394,14 +394,15 @@ class TibScholRelationMixin(VersionMixin, Relation, LegacyDateMixin, GenericMode
         abstract = True
 
 
-def enforce_plural_name(sender, **kwargs):
+def enforce_meta_attributes(sender, **kwargs):
     if issubclass(sender, TibScholRelationMixin):
         meta = sender._meta
         # set verbose_name_plural to verbose_name
         meta.verbose_name_plural = meta.verbose_name or sender.__name__.lower()
+        meta.ordering = ["subj_object_id", "obj_object_id"]
 
 
-class_prepared.connect(enforce_plural_name)
+class_prepared.connect(enforce_meta_attributes)
 
 
 class PersonActiveAtPlace(TibScholRelationMixin):


### PR DESCRIPTION
This pull request includes several changes to the `apis_ontology/models.py` file to improve the ordering of query results and to enforce specific meta attributes for certain models. The most important changes include adding ordering to multiple models and renaming a function to reflect its broader purpose.

Ordering improvements:

* [`apis_ontology/models.py`](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1R31): Added `ordering = ["name"]` to the `Subject` model.
* [`apis_ontology/models.py`](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1R117): Added `ordering = ["name", "pk"]` to the `Person`, `Work`, and `Instance` models. [[1]](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1R117) [[2]](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1R216) [[3]](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1R334)

Meta attribute enforcement:

* [`apis_ontology/models.py`](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1L393-R405): Renamed the `enforce_plural_name` function to `enforce_meta_attributes` and added logic to set `meta.ordering` for subclasses of `TibScholRelationMixin`.