### PR TITLE
disable sorting by subj/obj

### DIFF
--- a/apis_ontology/tables.py
+++ b/apis_ontology/tables.py
@@ -240,6 +240,10 @@ class TibScholRelationMixinTable(GenericTable):
     class Meta(GenericTable.Meta):
         fields = ["subj", "obj"]
         exclude = ["desc"]
+        sequence = ("subj", "obj", "...")
+
+    subj = tables.Column(verbose_name="Subject", orderable=False)
+    obj = tables.Column(verbose_name="Object", orderable=False)
 
     def render_subj(self, value):
         url = value.get_absolute_url()


### PR DESCRIPTION
This pull request includes changes to the `TibScholRelationMixinTable` class in the `apis_ontology/tables.py` file. The main updates involve the addition of new column definitions and modifications to the table's metadata.

Changes to `TibScholRelationMixinTable` class:

* Added `sequence` to the `Meta` class to define the order of fields.
* Introduced `subj` and `obj` columns with `verbose_name` and `orderable` attributes set to `False`.