### PR TITLE
hide relations menu for anonymous users

### DIFF
--- a/apis_ontology/settings/server_settings.py
+++ b/apis_ontology/settings/server_settings.py
@@ -17,10 +17,10 @@ INSTALLED_APPS += [
     "django_acdhch_functions",
     "django_select2",
 ]
-INSTALLED_APPS.remove("apis_ontology")
-INSTALLED_APPS.insert(0, "apis_ontology")
 INSTALLED_APPS = ["apis_core.relations"] + INSTALLED_APPS
 INSTALLED_APPS.append("apis_core.documentation")
+INSTALLED_APPS.remove("apis_ontology")
+INSTALLED_APPS.insert(0, "apis_ontology")
 
 
 LOGGING = {

--- a/apis_ontology/templates/base.html
+++ b/apis_ontology/templates/base.html
@@ -22,6 +22,14 @@ TibSchol: The Dawn of Tibetan Buddhist Scholasticism (11th–13th c.)
 {% endfor %}
 {% endblock entities-menu-items %}
 
+{% block relations-menu-items %}
+{% if user.is_authenticated %}
+{{ block.super }}
+{% else %}
+    <div id="relationsList"></div>
+{% endif %}
+{% endblock relations-menu-items %}
+
 {% block main-menu %}
 <li class="nav-item dropdown">
     <a href="#" class="nav-link dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"


### PR DESCRIPTION


This pull request includes changes to the `apis_ontology` project, focusing on the configuration of installed apps and the template for the base HTML file. The most important changes include adjustments to the `INSTALLED_APPS` list in the server settings and the addition of a new block for relations menu items in the base template.

Changes to server settings:

* [`apis_ontology/settings/server_settings.py`](diffhunk://#diff-2903b7820ed1f17f3d8fa1eee95d7bba39d40c18f6810445aa4f3fdfa84636baL20-R23): Adjusted the order of `apis_ontology` in the `INSTALLED_APPS` list to ensure it is on the top.

Changes to base template:

* [`apis_ontology/templates/base.html`](diffhunk://#diff-2d876f80b43737269e59ecad6f487d5c40d5cff2bed8b9645401bc561bb2785aR25-R32): Added a new block for `relations-menu-items` that displays different content based on the user's authentication status.