### PR TITLE
Rename Subject to Topic

### DIFF
--- a/apis_ontology/models.py
+++ b/apis_ontology/models.py
@@ -26,8 +26,8 @@ class Subject(GenericModel, models.Model):
         return self.name
 
     class Meta:
-        verbose_name = _("Subject")
-        verbose_name_plural = _("Subjects")
+        verbose_name = _("Topic")
+        verbose_name_plural = _("Topics")
         ordering = ["name"]
 
 
@@ -198,7 +198,7 @@ class Work(
         ("Other", "Other"),
     ]
 
-    subject_vocab = models.ManyToManyField(Subject, verbose_name="Subject", blank=True)
+    subject_vocab = models.ManyToManyField(Subject, verbose_name="Topic", blank=True)
     name = models.CharField(max_length=255, blank=True, default="", verbose_name="Name")
     sde_dge_ref = models.CharField(
         max_length=25, blank=True, null=True, verbose_name="Derge reference"


### PR DESCRIPTION
closes #240
This pull request includes changes to the `apis_ontology/models.py` file to update the terminology used for subjects to topics. The most important changes include modifying the verbose names for the `Subject` model and updating the `subject_vocab` field in the `Work` model.

Terminology updates:

* [`apis_ontology/models.py`](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1L29-R30): Changed the verbose names in the `Meta` class of the `Subject` model from "Subject" to "Topic" and from "Subjects" to "Topics".
* [`apis_ontology/models.py`](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1L201-R201): Updated the `verbose_name` attribute of the `subject_vocab` field in the `Work` model from "Subject" to "Topic".