### PR TITLE
Rename Subject of teaching to Topic of Teaching

### DIFF
--- a/apis_ontology/models.py
+++ b/apis_ontology/models.py
@@ -409,7 +409,7 @@ class PersonActiveAtPlace(TibScholRelationMixin):
     subj_model = Person
     obj_model = Place
     subject_of_teaching_vocab = models.ManyToManyField(
-        Subject, verbose_name="Subject of teaching", blank=True
+        Subject, verbose_name="Topic of teaching", blank=True
     )
 
     @classmethod
@@ -538,7 +538,7 @@ class PersonLineagePredecessorOfPerson(TibScholRelationMixin):
         return "lineage successor of"
 
     subject_of_teaching_vocab = models.ManyToManyField(
-        Subject, verbose_name="Subject of teaching", blank=True
+        Subject, verbose_name="Topic of teaching", blank=True
     )
 
 
@@ -675,7 +675,7 @@ class PersonQuotesWithNamePerson(TibScholRelationMixin):
         return "is quoted with name by"
 
     subject_of_teaching_vocab = models.ManyToManyField(
-        Subject, verbose_name="Subject of teaching", blank=True
+        Subject, verbose_name="Topic of teaching", blank=True
     )
 
 
@@ -692,7 +692,7 @@ class PersonQuotesWithoutNamePerson(TibScholRelationMixin):
         return "is quoted without name by"
 
     subject_of_teaching_vocab = models.ManyToManyField(
-        Subject, verbose_name="Subject of teaching", blank=True
+        Subject, verbose_name="Topic of teaching", blank=True
     )
 
 
@@ -709,7 +709,7 @@ class PersonRequestsPerson(TibScholRelationMixin):
         return "requested by"
 
     subject_of_teaching_vocab = models.ManyToManyField(
-        Subject, verbose_name="Subject of teaching", blank=True
+        Subject, verbose_name="Topic of teaching", blank=True
     )
 
 
@@ -765,7 +765,7 @@ class PersonStudentOfPerson(TibScholRelationMixin):
         return "teacher of"
 
     subject_of_teaching_vocab = models.ManyToManyField(
-        Subject, verbose_name="Subject of teaching", blank=True
+        Subject, verbose_name="Topic of teaching", blank=True
     )
 
 


### PR DESCRIPTION
This pull request includes several changes to the `apis_ontology/models.py` file, specifically updating the verbose name of the `subject_of_teaching_vocab` field across multiple methods. The main change involves renaming "Subject of teaching" to "Topic of teaching".

Changes to verbose names:

* Updated the `subject_of_teaching_vocab` field's verbose name from "Subject of teaching" to "Topic of teaching" in the 
  * `PersonActiveAtPlace` class.
  * "lineage successor of"
  * "is quoted with name by"
  * "is quoted without name by"
  * "requested by"
  * "teacher of" relations