### PR TITLE
Open relation predicate in a new tab

### DIFF
--- a/apis_ontology/templates/columns/relation_predicate.html
+++ b/apis_ontology/templates/columns/relation_predicate.html
@@ -1,9 +1,9 @@
 {% if record.forward %}
-<a href="{{ record.obj.get_absolute_url }}" style="{{ highlight_style }}">
+<a href="{{ record.obj.get_absolute_url }}" target="_blank" style="{{ highlight_style }}">
     {{ record.obj }}
 </a>
 {% else %}
-<a href="{{ record.subj.get_absolute_url }}" style="{{ highlight_style }}">
+<a href="{{ record.subj.get_absolute_url }}" target="_blank" style="{{ highlight_style }}">
     {{ record.subj }}
 </a>
 {% endif %}


### PR DESCRIPTION
This pull request includes a small change to the `apis_ontology/templates/columns/relation_predicate.html` file. The change ensures that links open in a new tab by adding the `target="_blank"` attribute to the anchor tags.

* [`apis_ontology/templates/columns/relation_predicate.html`](diffhunk://#diff-4577587eef7bdd688d3edad3153f02480787f79dfe5bb06fe1cf4c701db9595dL2-R6): Added `target="_blank"` attribute to anchor tags to open links in a new tab.

closes #245