### PR TITLE
define default search fields for autocomplete

### DIFF
--- a/apis_ontology/models.py
+++ b/apis_ontology/models.py
@@ -83,6 +83,7 @@ class Person(
     VersionMixin, LegacyStuffMixin, LegacyDateMixin, TibScholEntityMixin, AbstractEntity
 ):
     class_uri = "http://id.loc.gov/ontologies/bibframe/Person"
+    _default_search_fields = ["id", "name", "alternative_names"]
 
     start_date_written = models.CharField(
         max_length=255,
@@ -129,6 +130,8 @@ class Place(
     AbstractEntity,
 ):
     class_uri = "http://id.loc.gov/ontologies/bibframe/Place"
+    _default_search_fields = ["id", "label", "alternative_names"]
+
     label = models.CharField(blank=True, default="", verbose_name="Name")
     end_date = None
     end_start_date = None
@@ -180,6 +183,8 @@ class Work(
     VersionMixin, LegacyStuffMixin, LegacyDateMixin, TibScholEntityMixin, AbstractEntity
 ):
     class_uri = "http://id.loc.gov/ontologies/bibframe/Work"
+    _default_search_fields = ["id", "name", "alternative_names"]
+
     end_date = None
     end_start_date = None
     end_end_date = None
@@ -255,6 +260,8 @@ class Instance(
     VersionMixin, LegacyStuffMixin, LegacyDateMixin, TibScholEntityMixin, AbstractEntity
 ):
     class_uri = "http://id.loc.gov/ontologies/bibframe/Instance"
+    _default_search_fields = ["id", "name", "alternative_names"]
+
     end_date = None
     end_start_date = None
     end_end_date = None


### PR DESCRIPTION
This pull request includes updates to the `apis_ontology/models.py` file to add default search fields to several classes. The most important changes are the addition of `_default_search_fields` attributes to the `Person`, `Place`, `Work`, and `Instance` classes.

Updates to default search fields:

* [`apis_ontology/models.py`](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1R86): Added `_default_search_fields` attribute to `Person` class with fields `["id", "name", "alternative_names"]`.
* [`apis_ontology/models.py`](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1R133-R134): Added `_default_search_fields` attribute to `Place` class with fields `["id", "label", "alternative_names"]`.
* [`apis_ontology/models.py`](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1R186-R187): Added `_default_search_fields` attribute to `Work` class with fields `["id", "name", "alternative_names"]`.
* [`apis_ontology/models.py`](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1R263-R264): Added `_default_search_fields` attribute to `Instance` class with fields `["id", "name", "alternative_names"]`.
