### PR TITLE
allow exX TEI references also to be linkified

### DIFF
--- a/apis_ontology/tables.py
+++ b/apis_ontology/tables.py
@@ -196,7 +196,11 @@ class TEIRefColumn(TibScholRelationColumn):
             words = l.split()
             linked_words = []
             for w in words:
-                if w.startswith("xml:id=") or bool(re.search(r"\bex\d\w*", w)):
+                if (
+                    w.startswith("xml:id=")
+                    or bool(re.search(r"\bex(?:\d\w*)\b", w))
+                    or bool(re.search(r"\bexX(?:\w*)\b", w))
+                ):
                     linked_words.append(linkify_excerpt_id(w))
                 else:
                     linked_words.append(w)


### PR DESCRIPTION
This pull request includes an enhancement to the `linkify_excerpt_id` function in the `apis_ontology/tables.py` file. The change improves the regular expression patterns used to identify and process specific words.

Improvements to regular expression patterns:

* [`apis_ontology/tables.py`](diffhunk://#diff-2ff430a2f96c033674f5795bd02c89280acef6d6b3e3d755ec2456e5e12b4b54L199-R203): Modified the `linkify_excerpt_id` function to include an additional pattern `\bexX(?:\w*)\b` for matching words, ensuring more comprehensive identification of excerpt IDs.

closes #256