### PR TITLE
Work author

### DIFF
--- a/apis_ontology/tables.py
+++ b/apis_ontology/tables.py
@@ -490,3 +490,53 @@ class PersonSponsorOfInstanceTable(TibScholRelationMixinTable):
     author_work = AuthorColumn(
         verbose_name="Author", orderable=True, accessor="obj_object_id"
     )
+
+
+class PersonStudiesWorkTable(TibScholRelationMixinTable):
+    class Meta(TibScholRelationMixinTable.Meta):
+        fields = ["subj", "obj", "author_work"]
+        sequence = ("subj", "obj", "author_work", "...")
+
+    author_work = AuthorColumn(
+        verbose_name="Author", orderable=True, accessor="obj_object_id"
+    )
+
+
+class PersonTeachesWorkTable(TibScholRelationMixinTable):
+    class Meta(TibScholRelationMixinTable.Meta):
+        fields = ["subj", "obj", "author_work"]
+        sequence = ("subj", "obj", "author_work", "...")
+
+    author_work = AuthorColumn(
+        verbose_name="Author", orderable=True, accessor="obj_object_id"
+    )
+
+
+class WorkTaughtAtPlaceTable(TibScholRelationMixinTable):
+    class Meta(TibScholRelationMixinTable.Meta):
+        fields = ["subj", "obj", "author_work"]
+        sequence = ("subj", "author_work", "obj", "...")
+
+    author_work = AuthorColumn(
+        verbose_name="Author", orderable=True, accessor="subj_object_id"
+    )
+
+
+class PersonTranslatorOfWorkTable(TibScholRelationMixinTable):
+    class Meta(TibScholRelationMixinTable.Meta):
+        fields = ["subj", "obj", "author_work"]
+        sequence = ("subj", "obj", "author_work", "...")
+
+    author_work = AuthorColumn(
+        verbose_name="Author", orderable=True, accessor="obj_object_id"
+    )
+
+
+class PersonHasOtherRelationWithInstanceTable(TibScholRelationMixinTable):
+    class Meta(TibScholRelationMixinTable.Meta):
+        fields = ["subj", "obj", "author_work"]
+        sequence = ("subj", "obj", "author_work", "...")
+
+    author_work = AuthorColumn(
+        verbose_name="Author", orderable=True, accessor="obj_object_id"
+    )


### PR DESCRIPTION
This pull request introduces a new `AuthorColumn` class to handle rendering and ordering of author-related columns in the `apis_ontology/tables.py` file. The changes involve replacing existing author columns with instances of the new `AuthorColumn` class and adding several new relation tables.

### Introduction of `AuthorColumn`:

* [`apis_ontology/tables.py`](diffhunk://#diff-2ff430a2f96c033674f5795bd02c89280acef6d6b3e3d755ec2456e5e12b4b54R55-R93): Added `AuthorColumn` class to handle rendering and ordering of author-related columns.

### Replacement of existing author columns:

* [`apis_ontology/tables.py`](diffhunk://#diff-2ff430a2f96c033674f5795bd02c89280acef6d6b3e3d755ec2456e5e12b4b54L97-R136): Replaced existing `author` columns with `AuthorColumn` in `PlaceTable`, `InstanceTable`, `WorkCommentaryOnWorkTable`, and `WorkComposedAtPlaceTable`. [[1]](diffhunk://#diff-2ff430a2f96c033674f5795bd02c89280acef6d6b3e3d755ec2456e5e12b4b54L97-R136) [[2]](diffhunk://#diff-2ff430a2f96c033674f5795bd02c89280acef6d6b3e3d755ec2456e5e12b4b54L118-R145) [[3]](diffhunk://#diff-2ff430a2f96c033674f5795bd02c89280acef6d6b3e3d755ec2456e5e12b4b54L132-L153) [[4]](diffhunk://#diff-2ff430a2f96c033674f5795bd02c89280acef6d6b3e3d755ec2456e5e12b4b54L353-L377)

### Addition of new relation tables:

* [`apis_ontology/tables.py`](diffhunk://#diff-2ff430a2f96c033674f5795bd02c89280acef6d6b3e3d755ec2456e5e12b4b54R380-R542): Added new relation tables such as `PersonAddresseeOfWorkTable`, `PersonBiographedInWorkTable`, `WorkContainsCitationsOfWorkTable`, and others, each utilizing the new `AuthorColumn` for author-related fields.

Closes #72 