### PR TITLE
fix(tables): distinguish author columns

### DIFF
--- a/apis_ontology/tables.py
+++ b/apis_ontology/tables.py
@@ -424,10 +424,10 @@ class WorkContainsCitationsOfWorkTable(TibScholRelationMixinTable):
         sequence = ("subj", "author_subj", "obj", "author_obj", "...")
 
     author_subj = AuthorColumn(
-        verbose_name="Author", orderable=True, accessor="subj_object_id"
+        verbose_name="Author (subj)", orderable=True, accessor="subj_object_id"
     )
     author_obj = AuthorColumn(
-        verbose_name="Author", orderable=True, accessor="obj_object_id"
+        verbose_name="Author (obj)", orderable=True, accessor="obj_object_id"
     )
 
 


### PR DESCRIPTION
for subject and object fields

This pull request includes a minor update to the `apis_ontology/tables.py` file. The change involves modifying the `verbose_name` attributes of the `author_subj` and `author_obj` columns to provide clearer distinctions between the subject and object authors.

* [`apis_ontology/tables.py`](diffhunk://#diff-2ff430a2f96c033674f5795bd02c89280acef6d6b3e3d755ec2456e5e12b4b54L427-R430): Updated `verbose_name` for `author_subj` to "Author (subj)" and for `author_obj` to "Author (obj)" to improve clarity.