### PR TITLE
tables: use responsive striped/hover template

### DIFF
--- a/apis_ontology/settings/server_settings.py
+++ b/apis_ontology/settings/server_settings.py
@@ -69,3 +69,7 @@ MIDDLEWARE += [
 
 APIS_ANON_VIEWS_ALLOWED = False
 EXPORT_FORMATS = ()
+DJANGO_TABLES2_TEMPLATE = "django_tables2/bootstrap5-responsive.html"
+DJANGO_TABLES2_TABLE_ATTRS = {
+    "class": "table table-striped table-hover",
+}


### PR DESCRIPTION
Configuration updates:

* [`apis_ontology/settings/server_settings.py`](diffhunk://#diff-2903b7820ed1f17f3d8fa1eee95d7bba39d40c18f6810445aa4f3fdfa84636baR72-R75): Added a new template setting for Django Tables 2, specifying the use of "bootstrap5-responsive.html".
* [`apis_ontology/settings/server_settings.py`](diffhunk://#diff-2903b7820ed1f17f3d8fa1eee95d7bba39d40c18f6810445aa4f3fdfa84636baR72-R75): Added new table attributes to apply "table-striped" and "table-hover" classes to the tables.