### PR TITLE
remove overridden setting REST_FRAMEWORK

### DIFF
--- a/apis_ontology/settings/server_settings.py
+++ b/apis_ontology/settings/server_settings.py
@@ -57,10 +57,6 @@ CACHES = {
 }
 
 SELECT2_CACHE_BACKEND = "select2"
-REST_FRAMEWORK = {
-    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
-    "PAGE_SIZE": 20,
-}
 
 MIDDLEWARE += [
     "simple_history.middleware.HistoryRequestMiddleware",


### PR DESCRIPTION
to use correct acdhch default setting

This pull request includes changes to the `apis_ontology/settings/server_settings.py` file to remove unnecessary configurations and streamline the settings. The most important change involves the removal of the REST framework pagination settings.

Settings cleanup:

* [`apis_ontology/settings/server_settings.py`](diffhunk://#diff-2903b7820ed1f17f3d8fa1eee95d7bba39d40c18f6810445aa4f3fdfa84636baL60-L63): Removed the `REST_FRAMEWORK` configuration block, which included the `DEFAULT_PAGINATION_CLASS` and `PAGE_SIZE` settings.

