### PR TITLE
add support for xlsx format

### DIFF
--- a/apis_ontology/settings/server_settings.py
+++ b/apis_ontology/settings/server_settings.py
@@ -64,7 +64,7 @@ MIDDLEWARE += [
 
 
 APIS_ANON_VIEWS_ALLOWED = False
-EXPORT_FORMATS = ("csv",)
+EXPORT_FORMATS = ("csv", "xlsx")
 DJANGO_TABLES2_TEMPLATE = "django_tables2/bootstrap5-responsive.html"
 DJANGO_TABLES2_TABLE_ATTRS = {
     "class": "table table-striped table-hover",

--- a/poetry.lock
+++ b/poetry.lock
@@ -977,6 +977,17 @@ offline = ["drf-spectacular-sidecar"]
 sidecar = ["drf-spectacular-sidecar"]
 
 [[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+description = "An implementation of lxml.xmlfile for the standard library"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa"},
+    {file = "et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54"},
+]
+
+[[package]]
 name = "executing"
 version = "2.2.0"
 description = "Get the currently executing AST node of a frame, and other information"
@@ -1979,6 +1990,20 @@ files = [
     {file = "numpy-2.2.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:356ca982c188acbfa6af0d694284d8cf20e95b1c3d0aefa8929376fea9146f60"},
     {file = "numpy-2.2.2.tar.gz", hash = "sha256:ed6906f61834d687738d25988ae117683705636936cc605be0bb208b23df4d8f"},
 ]
+
+[[package]]
+name = "openpyxl"
+version = "3.1.5"
+description = "A Python library to read/write Excel 2010 xlsx/xlsm files"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2"},
+    {file = "openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050"},
+]
+
+[package.dependencies]
+et-xmlfile = "*"
 
 [[package]]
 name = "opentelemetry-api"
@@ -3269,6 +3294,9 @@ files = [
     {file = "tablib-3.8.0.tar.gz", hash = "sha256:94d8bcdc65a715a0024a6d5b701a5f31e45bd159269e62c73731de79f048db2b"},
 ]
 
+[package.dependencies]
+openpyxl = {version = ">=2.6.0", optional = true, markers = "extra == \"xlsx\""}
+
 [package.extras]
 all = ["odfpy", "openpyxl (>=2.6.0)", "pandas", "pyyaml", "tabulate", "xlrd", "xlwt"]
 cli = ["tabulate"]
@@ -3643,4 +3671,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "b0921932c476bd1dd62f7fbdc6ff45ea9f797643e6a838eb87cdd55bd81b99e8"
+content-hash = "5b9afe8f0be07ec32f2c7ccafc8cff7b52c517a10b6ed1b6783db748828ade92"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ django-extensions = "^3.1.3"
 tqdm = "^4.67.1"
 pandas = "^2.2.2"
 django-select2 = "^8.2.3"
+tablib = {extras = ["xlsx"], version = "^3.8.0"}
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
This pull request includes updates to the export functionality and dependencies in the project. The most important changes are:

Export functionality:

* [`apis_ontology/settings/server_settings.py`](diffhunk://#diff-2903b7820ed1f17f3d8fa1eee95d7bba39d40c18f6810445aa4f3fdfa84636baL67-R67): Added support for exporting data in `xlsx` format in addition to `csv`.

Dependencies:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R20): Added `tablib` dependency with `xlsx` extras to support the new export format.

Closes #293 