### PR TITLE
remove preview for references column

### DIFF
--- a/apis_ontology/tables.py
+++ b/apis_ontology/tables.py
@@ -312,17 +312,7 @@ class TibScholEntityMixinRelationsTable(GenericTable):
     predicate = RelationPredicateColumn()
     references = MoreLessColumn(
         orderable=False,
-        preview=lambda x: mark_safe(
-            render_tei_refs(getattr(x, "tei_refs", "") or "")
-            + parse_comment(
-                render_list_field(
-                    preview_text(
-                        f"{getattr(x,'support_notes', '') or ''}\n{getattr(x, 'zotero_refs','') or ''}",
-                        100,
-                    )
-                )
-            )
-        ),
+        preview=lambda x: "",
         fulltext=lambda x: mark_safe(
             render_tei_refs(getattr(x, "tei_refs", "") or "")
             + parse_comment(


### PR DESCRIPTION
closes #292

This pull request includes a change to the `TibScholEntityMixinRelationsTable` class in the `apis_ontology/tables.py` file. The most important change involves simplifying the `references` column by altering its `preview` lambda function to return an empty string instead of rendering a complex HTML preview.

Simplification of code:

* [`apis_ontology/tables.py`](diffhunk://#diff-2ff430a2f96c033674f5795bd02c89280acef6d6b3e3d755ec2456e5e12b4b54L315-R315): Modified the `preview` lambda function in the `references` column of the `TibScholEntityMixinRelationsTable` class to return an empty string, removing the previous logic that rendered a combination of TEI references and support notes.