### PR TITLE
excerpts: fix gloss behaviour to show content inside ‹›

### DIFF
--- a/apis_ontology/static/scripts/render_tei.js
+++ b/apis_ontology/static/scripts/render_tei.js
@@ -107,9 +107,9 @@ let behaviors = {
       let result = document.createElement("span");
       result.classList.add("note");
       if (e.getAttribute("type") === "gloss") {
-        // result.appendChild(document.createTextNode(" ‹"+e.textContent+"› "));
-        //       // Process child nodes and append
+        result.appendChild(document.createTextNode(" ‹"));
         result.appendChild(processChildNodes(e, behaviors));
+        result.appendChild(document.createTextNode("› "));
       } else {
         result.innerHTML ="<span class='material-symbols-outlined button'>description</span>";
         result.title = e.textContent;


### PR DESCRIPTION
This pull request updates the behavior of rendering gloss notes in the `render_tei.js` script. The key change is the reintroduction of child node processing for gloss notes, ensuring that their content is dynamically processed and displayed correctly.

### Changes to gloss note rendering:
* [`apis_ontology/static/scripts/render_tei.js`](diffhunk://#diff-11b88f765b7461153e94db8782837fbb3fc6517543f9d4549a8ef7a3d2664238L110-R112): Updated the handling of gloss notes to dynamically process child nodes using the `processChildNodes` function. This replaces the previous commented-out logic and ensures proper rendering of gloss content within angle brackets.