### PR TITLE
custom auto-deploy-values to fetch zotero entries

### DIFF
--- a/.github/workflows/auto-deploy-values.yaml
+++ b/.github/workflows/auto-deploy-values.yaml
@@ -1,0 +1,54 @@
+replicaCount: 1
+
+image:
+  repository: $repository
+  tag: "$tag"
+  pullPolicy: Always
+
+extraLabels:
+  "ID": "$service_id"
+
+gitlab:
+  app: "$app_name"
+  envURL: "$repo_url"
+
+service:
+  enabled: true
+  name: "web"
+  url: "$public_url"
+  additionalHosts:
+    - ${app_name_in_url}-${ref_name}.${kube_ingress_base_domain}
+  type: ClusterIP
+  externalPort: 5000 #${{ inputs.default_port }}
+  internalPort: 5000 #${{ inputs.default_port }}
+
+ingress:
+  enabled: true
+  path: "/"
+  annotations:
+    kubernetes.io/ingressClassName: "nginx"
+
+livenessProbe:
+  path: "/" #"${{ inputs.APP_ROOT }}"
+  initialDelaySeconds: 15
+  timeoutSeconds: 15
+  scheme: "HTTP"
+  probeType: "httpGet"
+
+readinessProbe:
+  path: "/" #"${{ inputs.APP_ROOT }}"
+  initialDelaySeconds: 5
+  timeoutSeconds: 3
+  scheme: "HTTP"
+  probeType: "httpGet"
+
+
+cronjobs:
+  import:
+    schedule: "0 12 * * *"
+    command: ["/bin/bash"]
+    args: ["-c", "./manage.py fetch_zotero_entries"]
+    image:
+      repository: $repository
+      tag: "$tag"
+      pullPolicy: IfNotPresent


### PR DESCRIPTION
automatically every day at noon; inspired by [nsvis](https://github.com/acdh-oeaw/apis-instance-nsvis)

This pull request introduces a new configuration file, `.github/workflows/auto-deploy-values.yaml`, to define deployment settings for an application. The file includes settings for replicas, image details, service configuration, ingress, probes, and cronjobs.

### Deployment Configuration:
* Added `replicaCount` to specify the number of replicas for the application.
* Defined image properties, including `repository`, `tag`, and `pullPolicy`.
* Configured service details, such as `enabled`, `name`, `url`, `type`, and port mappings.
* Enabled ingress with a specified path and annotations for the ingress class.

### Health Checks:
* Added `livenessProbe` and `readinessProbe` configurations to monitor application health, with HTTP checks on the root path and customizable delay and timeout settings.

### Scheduled Tasks:
* Introduced a cronjob configuration to schedule a task (`fetch_zotero_entries`) with a specified schedule, command, arguments, and image properties.