### PR TITLE
datamodel: adjacency matrix representation of the data model

### DIFF
--- a/apis_ontology/data_model_utils.py
+++ b/apis_ontology/data_model_utils.py
@@ -1,0 +1,45 @@
+from collections import defaultdict
+from apis_core.apis_entities.utils import get_entity_content_types
+from apis_core.relations.utils import relation_content_types
+
+
+class DataModel:
+    entities: list = []
+    relations: list = []
+    matrix = defaultdict(dict)
+
+    def __init__(self):
+        self.entities = get_entity_content_types()
+        self.relations = relation_content_types()
+        self.matrix = defaultdict(dict)
+
+        for rel in self.relations:
+            rel_model = rel.model_class()
+            print(
+                rel_model, rel_model.subj_model.__name__, rel_model.obj_model.__name__
+            )
+            if (
+                str(rel_model.subj_model.__name__)
+                in self.matrix[str(rel_model.obj_model.__name__)]
+            ):
+                self.matrix[str(rel_model.subj_model.__name__)][
+                    str(rel_model.obj_model.__name__)
+                ].append(rel_model.name())
+
+                self.matrix[str(rel_model.obj_model.__name__)][
+                    str(rel_model.subj_model.__name__)
+                ].append(rel_model.reverse_name())
+
+            else:
+                self.matrix[str(rel_model.subj_model.__name__)][
+                    str(rel_model.obj_model.__name__)
+                ] = [rel_model.name()]
+                self.matrix[str(rel_model.obj_model.__name__)][
+                    str(rel_model.subj_model.__name__)
+                ] = [rel_model.reverse_name()]
+
+        print(self.matrix)
+        # sort the relations
+        for row in self.matrix:
+            for col in self.matrix[row]:
+                self.matrix[row][col] = sorted(list(set(self.matrix[row][col])))

--- a/apis_ontology/templates/base.html
+++ b/apis_ontology/templates/base.html
@@ -29,7 +29,7 @@ TibSchol: The Dawn of Tibetan Buddhist Scholasticism (11th–13th c.)
         About <span class="caret" />
     </a>
     <div class="dropdown-menu" aria-labelledby="navbarDropdown">
-        <a class="dropdown-item" href="{% url 'apis:documentation' %}">Data model</a>
+        <a class="dropdown-item" href="{% url 'datamodel' %}">Data model</a>
     </div>
 </li>
 {{ block.super }}

--- a/apis_ontology/templates/datamodel.html
+++ b/apis_ontology/templates/datamodel.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+{% load core %}
+{% load generic %}
+{% load i18n %}
+{% load datamodel %}
+
+{% block content %}
+<div class="text-center align-middle">
+    <table class="table table-bordered table-striped table-hover">
+        <thead class="table-light">
+        <tr>
+                <th></th>
+                {% for col in datamodel.entities %}
+                <th class="text-center align-middle">{{ col.name | title }}</th>
+                {% endfor %}
+            </tr>
+        </thead>
+        <tbody>
+            {% for row in datamodel.entities %}
+            <tr>
+                <th class="text-center align-middle">{{ row.name |title }}</th>
+                {% for col in datamodel.entities %}
+                <td class="align-middle">
+                    {% for rel in datamodel.matrix|get_item:row.name|get_item:col.name %}
+                        {{rel}}<br>
+                    {% endfor %}
+                </td>
+                {% endfor %}
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+</div>
+
+{% endblock content %}

--- a/apis_ontology/templatetags/datamodel.py
+++ b/apis_ontology/templatetags/datamodel.py
@@ -1,0 +1,12 @@
+# templatetags/utils.py
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def get_item(dictionary, key):
+    if dictionary:
+        return dictionary.get(key.title(), "")
+
+    return ""

--- a/apis_ontology/urls.py
+++ b/apis_ontology/urls.py
@@ -1,4 +1,4 @@
-from apis_ontology.views import ExcerptsView
+from apis_ontology.views import DataModelView, ExcerptsView
 from django.contrib import admin
 from django.urls import include, path
 from django.views.generic import TemplateView
@@ -19,6 +19,11 @@ urlpatterns = [
         "apis/excerpts/<str:xml_id>/<str:render_style>/",
         ExcerptsView.as_view(),
         name="excerpts_view",
+    ),
+    path(
+        "apis/datamodel/",
+        DataModelView.as_view(),
+        name="datamodel",
     ),
 ]
 

--- a/apis_ontology/views.py
+++ b/apis_ontology/views.py
@@ -1,7 +1,9 @@
 from django.http import JsonResponse
 from django.views import View
 from django.shortcuts import get_object_or_404
+from django.views.generic.base import TemplateView
 from .models import Excerpts, Instance
+from .data_model_utils import DataModel
 
 
 class ExcerptsView(View):
@@ -34,3 +36,12 @@ class ExcerptsView(View):
         }
 
         return JsonResponse(data)  # Return the data as JSON response
+
+
+class DataModelView(TemplateView):
+    template_name = "datamodel.html"
+
+    def get_context_data(self):
+        ctx = super().get_context_data()
+        ctx["datamodel"] = DataModel()
+        return ctx


### PR DESCRIPTION
This pull request introduces a new feature to display a data model matrix in the application, along with supporting changes to the backend, templates, and URL routing. The most important changes include adding a `DataModel` class to generate the matrix, creating a new template and view for rendering the data model, and updating the navigation to include a link to the data model page.

### Backend changes:
* Added a `DataModel` class in `apis_ontology/data_model_utils.py` to generate a matrix of entities and their relationships using `get_entity_content_types` and `relation_content_types`. The matrix is sorted and ensures unique relationships are displayed.
* Created a `get_item` template filter in `apis_ontology/templatetags/datamodel.py` to retrieve values from dictionaries by key, supporting the rendering of the data model matrix.

### Frontend changes:
* Added a new template `apis_ontology/templates/datamodel.html` to render the data model matrix as a table, displaying entities and their relationships in a user-friendly format.
* Updated the `apis_ontology/templates/base.html` navigation bar to include a link to the new data model page.

### Routing and view changes:
* Added a `DataModelView` class in `apis_ontology/views.py` to serve the data model page, passing the `DataModel` instance to the template context.
* Updated `apis_ontology/urls.py` to include a new route for the data model page at `apis/datamodel/`. [[1]](diffhunk://#diff-f4051c017f27901a819ed4f672fc890dbc5d9cf69c4579c85680f109ca3902c2L1-R1) [[2]](diffhunk://#diff-f4051c017f27901a819ed4f672fc890dbc5d9cf69c4579c85680f109ca3902c2R23-R27)