### PR TITLE
feat(excerpts): apply colours to rs links

### DIFF
--- a/apis_ontology/static/scripts/render_tei.js
+++ b/apis_ontology/static/scripts/render_tei.js
@@ -65,6 +65,7 @@ let behaviors = {
       result.setAttribute("target", "_BLANK");
       result.setAttribute("href", "/apis/apis_ontology."+e.getAttribute("type")+"/"+e.getAttribute("ref").split(":")[1]);
       result.setAttribute("title", "type: " + e.getAttribute("type") + ", id: " + e.getAttribute("ref"));
+      result.classList.add("rs-"+e.getAttribute("type"));
       result.appendChild(processChildNodes(e, behaviors));
       return result;
     },

--- a/apis_ontology/static/styles/tei.css
+++ b/apis_ontology/static/styles/tei.css
@@ -115,3 +115,15 @@ blockquote{
 .choice{
   color: green;
 }
+
+.rs-work{
+  color: blue;
+}
+
+.rs-person{
+  color: maroon;
+}
+
+.rs-place{
+  color: darkolivegreen;
+}


### PR DESCRIPTION
closes #370

This pull request introduces enhancements to the rendering and styling of TEI elements in the `apis_ontology` module. The changes primarily involve adding CSS classes to dynamically generated elements and defining corresponding styles to improve visual differentiation based on element types.

### Rendering Enhancements:
* [`render_tei.js`](diffhunk://#diff-11b88f765b7461153e94db8782837fbb3fc6517543f9d4549a8ef7a3d2664238R68): Added a new class (`rs-[type]`) to dynamically generated elements based on their `type` attribute. This allows for easier styling and identification of different TEI element types.

### Styling Improvements:
* [`tei.css`](diffhunk://#diff-fc22934d0b6f41e51100ac3f06aa5be2847480f415938393205e04e36efa63b9R118-R129): Added new CSS rules for `.rs-work`, `.rs-person`, and `.rs-place` classes, assigning distinct colors (blue, maroon, and dark olive green, respectively) to visually differentiate these element types.