### PR TITLE
management: parameterise excerpts import file

### DIFF
--- a/apis_ontology/management/commands/import_excerpts.py
+++ b/apis_ontology/management/commands/import_excerpts.py
@@ -13,15 +13,23 @@ class Command(BaseCommand):
     Imports excerpts from data/excerpts.csv
     """
 
+    def add_arguments(self, parser):
+        parser.add_argument("dump", type=str, help="dump file name")
+
     def handle(self, *args, **kwargs):
         def create_record(row):
             record, _ = Excerpts.objects.get_or_create(xml_id=row.xml_id)
             record.__dict__.update(row.to_dict())
             record.save()
 
-        print(len(Excerpts.objects.all()))
-        import_file = "data/excerpts.csv"
+        # define an input parameter for import_file
+
+        print(f"Found {len(Excerpts.objects.all())} excerpts in the database")
+        import_file = kwargs["dump"]
+
         df = pd.read_csv(import_file).fillna("")
+        print(f"Importing {df.shape[0]} excerpts from {import_file}")
+
         for _, row in tqdm(df.iterrows(), total=df.shape[0]):
             create_record(row)
 


### PR DESCRIPTION
This pull request introduces enhancements to the `import_excerpts.py` management command to improve flexibility and provide clearer feedback during execution. The most important changes include adding support for a command-line argument to specify the input file and improving logging for better user feedback.

### Enhancements to command-line arguments and logging:

* Added a new `add_arguments` method to define a `dump` argument, allowing users to specify the input file name when running the command.
* Updated the `handle` method to use the `dump` argument for the `import_file` variable, replacing the hardcoded file path. This makes the command more flexible.
* Improved logging by adding messages to indicate the number of excerpts in the database and the number of excerpts being imported from the specified file.