### PR TITLE
fix(place): show add relations buttons in edit view

### DIFF
--- a/apis_ontology/templates/apis_ontology/place_form.html
+++ b/apis_ontology/templates/apis_ontology/place_form.html
@@ -1,5 +1,5 @@
 {% extends "apis_core/apis_entities/abstractentity_form.html" %}
 
 {% block relations-include %}
-{% include "relations/list_relations_include_tabs.html" with edit=True %}
+{% include "relations/list_relations_include_tabs.html" with linkify=True %}
 {% endblock relations-include %}


### PR DESCRIPTION
This pull request introduces a small change to the `place_form.html` template. The change updates the `list_relations_include_tabs.html` template to use the `linkify` parameter instead of the `edit` parameter, likely to enable clickable links in the relations list.