### PR TITLE
feat(relations): show confidence value with icons

### DIFF
--- a/apis_ontology/static/styles/tibschol.css
+++ b/apis_ontology/static/styles/tibschol.css
@@ -44,3 +44,7 @@ pre#rawTEI{
 .modal-header{
   align-items: normal !important;
 }
+
+.relation-confidence{
+  vertical-align: middle;
+}

--- a/apis_ontology/templates/columns/relation_name.html
+++ b/apis_ontology/templates/columns/relation_name.html
@@ -3,3 +3,9 @@
 {% else %}
   {{ record.reverse_name }}
 {% endif %}
+
+{% if record.confidence == "Uncertain" %}
+  <span class="relation-confidence text-warning material-symbols-outlined">indeterminate_question_box</span>
+{% elif record.confidence == "Negative" %}
+  <span class="relation-confidence text-danger  material-symbols-outlined">report</span>
+{% endif %}


### PR DESCRIPTION
for uncertain and negative confidences

closes #372

This pull request introduces enhancements to the user interface for displaying relation confidence levels in the `apis_ontology` project. It includes styling updates and new visual indicators for specific confidence statuses.

### UI Enhancements for Relation Confidence:

* **Styling Update**: Added a new CSS class `.relation-confidence` with `vertical-align: middle` to ensure consistent alignment of confidence indicators. (`apis_ontology/static/styles/tibschol.css`, [apis_ontology/static/styles/tibschol.cssR47-R50](diffhunk://#diff-8b51716e1c7ad327090d05e71a05442884713f6eb743d9fd4bf90a9173a23cb9R47-R50))
* **Visual Indicators**: Introduced conditional rendering of icons for "Uncertain" and "Negative" confidence levels using `material-symbols-outlined` icons with appropriate classes for warning (`text-warning`) and danger (`text-danger`) styles. (`apis_ontology/templates/columns/relation_name.html`, [apis_ontology/templates/columns/relation_name.htmlR6-R11](diffhunk://#diff-17aab959cbee1879036551ecddd07a52b09a035eb926c4e22f0184029f09bb70R6-R11))