### PR TITLE
feat(management): show pk from rs tags in errors

### DIFF
--- a/apis_ontology/management/commands/verify_rs_tags.py
+++ b/apis_ontology/management/commands/verify_rs_tags.py
@@ -60,7 +60,7 @@ class Command(BaseCommand):
                                 {
                                     **error_template,
                                     "model": model_name,
-                                    "error": "entity not found",
+                                    "error": f"db:{pk} not found",
                                 }
                             )
                     except Exception as e:


### PR DESCRIPTION
This pull request includes a minor update to the error message in the `handle` method of `verify_rs_tags.py`. The change improves clarity by including the primary key (`pk`) in the error message when an entity is not found.

* [`apis_ontology/management/commands/verify_rs_tags.py`](diffhunk://#diff-97a83a29faeba1051232920ed0e35fa3dbcea85e18db3044560e53ddc1d19419L63-R63): Updated the error message to include `db:{pk}` for better debugging context.