### PR TITLE
templates(work): show "Topic" instead of "Subject"

### DIFF
--- a/apis_ontology/templates/apis_ontology/work_card_table.html
+++ b/apis_ontology/templates/apis_ontology/work_card_table.html
@@ -22,7 +22,7 @@
     {% endif %}
     {% if object.subject_vocab.exists %}
         <tr>
-            <th>Subject</th>
+            <th>Topic</th>
             <td>
                 {% for sub in object.subject_vocab.all %}
                     {{ sub.name }}<br/>


### PR DESCRIPTION
closes #411
This pull request includes a small change to the `work_card_table.html` template. The change updates the column header from "Subject" to "Topic" to better align with the terminology used in the application.