### PR TITLE
templates(work): removes extra linebreaks in comments…

### DIFF
--- a/apis_ontology/templates/apis_ontology/work_card_table.html
+++ b/apis_ontology/templates/apis_ontology/work_card_table.html
@@ -60,7 +60,7 @@
                 Comments
             </th>
             <td>
-                {{ object.comments | parse_comment | render_tei_refs | safe}}
+                {{ object.comments |render_tei_refs | parse_comment |safe}}
             </td>
         </tr>
     {% endif %}

--- a/apis_ontology/templatetags/render_tei_refs.py
+++ b/apis_ontology/templatetags/render_tei_refs.py
@@ -19,9 +19,7 @@ def render_tei_refs(value):
 
     def linkify_excerpt_id(xml_id):
         true_id = xml_id.replace('"', "").replace("xml:id=", "").strip().rstrip(".")
-        return f"""<a href="#" onclick="showExcerpt('{true_id}'); return false;">
-        {true_id}
-        </a> """
+        return f"""<a href='#' onclick="showExcerpt('{true_id}'); return false;">{true_id}</a>"""
 
     if not value.strip():
         return ""


### PR DESCRIPTION
when rendering comments with excerpts
fixes #410

### Changes to templates:

* [`apis_ontology/templates/apis_ontology/work_card_table.html`](diffhunk://#diff-2f41ca73540bbfc62a8c33744ae19d1c23bdfdb2443cfc4d0665968c4084fff9L63-R63): Reordered the `parse_comment` and `render_tei_refs` filters in the `object.comments` rendering pipeline to ensure `render_tei_refs` is applied before `parse_comment`.

### Changes to utility functions:

* [`apis_ontology/templatetags/render_tei_refs.py`](diffhunk://#diff-86e8ee9c21d358157ffa72d9b9dbd738c221ee01e1044883255f24d9ba7a92cfL22-R22): Simplified the `linkify_excerpt_id` function by removing unnecessary line breaks in the returned HTML string, improving readability and consistency.