### PR TITLE
cron: update excerpts-in-use collection after importing

### DIFF
--- a/.github/auto-deploy-values.yaml
+++ b/.github/auto-deploy-values.yaml
@@ -56,7 +56,7 @@ cronjobs:
   excerpts:
     schedule: '0 6,13,18,23 * * *'
     command: ["/bin/bash"]
-    args: ["-c", "python manage.py import_excerpts"]
+    args: ["-c", "python manage.py import_excerpts && python manage.py excerpts-in-use-collection"]
     image:
       repository: $repository
       tag: "$tag"


### PR DESCRIPTION
This pull request updates the `cronjobs` configuration in the `.github/auto-deploy-values.yaml` file to enhance functionality by adding a new task to the `excerpts` job.

**Key change:**

* Updated the `args` for the `excerpts` cronjob to include an additional command, `python manage.py excerpts-in-use-collection`, which will now run after `python manage.py import_excerpts`. 