### PR TITLE
Instance/Work - Instance relations tab

### DIFF
--- a/apis_ontology/tables.py
+++ b/apis_ontology/tables.py
@@ -391,6 +391,22 @@ class EntityRelationAuthorColumn(CustomTemplateColumn):
         return ""
 
 
+class RelationInstanceColumn(CustomTemplateColumn):
+    template_name = "apis_ontology/instance_details_column.html"
+    verbose_name = "Object details"
+    orderable = False
+
+    def render(self, record, **kwargs):
+        instance_id = record.obj_object_id if record.forward else record.subj_object_id
+        instance = Instance.objects.get(pk=instance_id)
+        self.extra_context = {
+            "instance": instance,
+            "lost": instance.availability == "lost",
+            "non_accessible": instance.availability == "non-accessible",
+        }
+        return super().render(instance, **kwargs)
+
+
 class TibScholEntityMixinWorkRelationsTable(TibScholEntityMixinRelationsTable):
     work_author = EntityRelationAuthorColumn()
 
@@ -406,6 +422,8 @@ class TibScholEntityMixinInstanceRelationsTable(TibScholEntityMixinWorkRelations
 
 
 class InstanceTabRelationsTable(TibScholEntityMixinRelationsTable):
+    instance = RelationInstanceColumn()
+
     class Meta(TibScholEntityMixinRelationsTable.Meta):
         pass
 

--- a/apis_ontology/templates/apis_ontology/instance_details_column.html
+++ b/apis_ontology/templates/apis_ontology/instance_details_column.html
@@ -1,0 +1,19 @@
+<div>
+    <span class="material-symbols-outlined text-danger align-middle">
+        {% if lost %}
+            close
+        {% elif non_accessible %}
+            lock
+        {% endif %}
+    </span>
+    {% if instance.num_folios %}
+    Number of folios: {{instance.num_folios}}<br>
+    {% endif %}
+    {% if instance.item_description %}
+    {{instance.item_description}}<br>
+    {% endif %}
+    {% if instance.comments %}
+    {{instance.comments}}<br>
+    {% endif %}
+
+</div>


### PR DESCRIPTION
This pull request introduces a new `RelationInstanceColumn` class to enhance the display of instance-related details in tables and updates table classes to incorporate this new column. Additionally, a new template is added to render instance details with specific visual cues.

### Enhancements to table functionality:

* **`RelationInstanceColumn` class**: Added a new column type to display instance details, including availability status (e.g., "lost" or "non-accessible") and other attributes. This column uses a custom template for rendering. (`apis_ontology/tables.py`, [apis_ontology/tables.pyR394-R409](diffhunk://#diff-2ff430a2f96c033674f5795bd02c89280acef6d6b3e3d755ec2456e5e12b4b54R394-R409))

* **New table classes**: Introduced `InstanceTabRelationsTable`, `InstanceInstanceRelationsTable`, and `WorkInstanceRelationsTable` to utilize the `RelationInstanceColumn` for displaying instance-related data in various contexts. (`apis_ontology/tables.py`, [apis_ontology/tables.pyR424-R440](diffhunk://#diff-2ff430a2f96c033674f5795bd02c89280acef6d6b3e3d755ec2456e5e12b4b54R424-R440))

### Template for instance details:

* **`instance_details_column.html`**: Added a new template to render instance details, including visual indicators for availability (e.g., icons for "lost" or "non-accessible") and additional information such as the number of folios, item descriptions, and comments. (`apis_ontology/templates/apis_ontology/instance_details_column.html`, [apis_ontology/templates/apis_ontology/instance_details_column.htmlR1-R19](diffhunk://#diff-3fa6c5ca4c3de7edb0032493b25498727b895fc79fb40d0941dc815c753b138cR1-R19))