### PR TITLE
tei: render app tag with lemma and alternate readings

### DIFF
--- a/apis_ontology/static/scripts/render_tei.js
+++ b/apis_ontology/static/scripts/render_tei.js
@@ -158,7 +158,35 @@ let behaviors = {
       }
 
       return result;
-    }  }
+    },
+    "app": function(e) {
+      const result = document.createElement("span");
+      const lem = e.querySelector("tei-lem");
+      const rdgs = e.querySelectorAll("tei-rdg");
+      let titleText = "";
+      if (lem.getAttribute("wit")) {
+        titleText = "wit: " + lem.getAttribute("wit").replace(" ",", ").replace("inst:","ID:").trim() + "\n";
+      }
+      for (let rdg of rdgs) {
+        let witness = ""
+        if (rdg.getAttribute("wit")) {
+          witness= "(" + rdg.getAttribute("wit").replace("inst:","ID:").trim() + ") ";
+        }
+        titleText = titleText + witness + rdg.textContent + "\n";
+      }
+      let displayNode = null;
+      if (lem) {
+        displayNode = lem.cloneNode(true);
+      }
+      if (displayNode) {
+        result.appendChild(processChildNodes(displayNode, behaviors));
+        result.title = titleText;
+        result.classList.add("app");
+        result.classList.add("pointer");
+      }
+      return result;
+    }
+  }
 };
 
 c.addBehaviors(behaviors);

--- a/apis_ontology/static/styles/tei.css
+++ b/apis_ontology/static/styles/tei.css
@@ -109,7 +109,7 @@ blockquote{
   margin: 0.5rem 2rem !important;
 }
 
-.choice{
+.choice, .app{
   color: green;
 }
 


### PR DESCRIPTION
This pull request introduces a new behavior and styling for elements with the class `app` in the TEI rendering system. The most important changes include adding a new behavior to process `app` elements in `render_tei.js` and updating the CSS to style these elements.

### Functional Enhancements:
* [`render_tei.js`](diffhunk://#diff-11b88f765b7461153e94db8782837fbb3fc6517543f9d4549a8ef7a3d2664238L161-R189): Added a new behavior for handling `app` elements. This includes creating a `span` element, processing its child nodes, setting a `title` attribute with formatted content from `tei-lem` and `tei-rdg` elements, and applying specific classes (`app` and `pointer`).

### Styling Updates:
* [`tei.css`](diffhunk://#diff-fc22934d0b6f41e51100ac3f06aa5be2847480f415938393205e04e36efa63b9L112-R112): Updated the `.choice` CSS rule to also apply to `.app` elements, setting their text color to green.