### PR TITLE
fix: show better hint for app

### DIFF
--- a/apis_ontology/static/scripts/render_tei.js
+++ b/apis_ontology/static/scripts/render_tei.js
@@ -165,12 +165,12 @@ let behaviors = {
       const rdgs = e.querySelectorAll("tei-rdg");
       let titleText = "";
       if (lem.getAttribute("wit")) {
-        titleText = "wit: " + lem.getAttribute("wit").replace(" ",", ").replace("inst:","ID:").trim() + "\n";
+        titleText = "wit: " + lem.getAttribute("wit").replaceAll(" ",", ").replaceAll("inst:","ID:").trim() + "\n";
       }
       for (let rdg of rdgs) {
         let witness = ""
         if (rdg.getAttribute("wit")) {
-          witness= "(" + rdg.getAttribute("wit").replace("inst:","ID:").trim() + ") ";
+          witness= "(" + rdg.getAttribute("wit").replaceAll("inst:","ID:").trim() + ") ";
         }
         titleText = titleText + witness + rdg.textContent + "\n";
       }


### PR DESCRIPTION
This pull request includes a small change to the `render_tei.js` file. The change replaces the use of `.replace` with `.replaceAll` for string replacements to ensure all occurrences of the target substrings are replaced.

* [`apis_ontology/static/scripts/render_tei.js`](diffhunk://#diff-11b88f765b7461153e94db8782837fbb3fc6517543f9d4549a8ef7a3d2664238L168-R173): Updated string replacement logic to use `.replaceAll` instead of `.replace` for attributes `wit` and `inst:` in `lem` and `rdg` elements.