### PR TITLE
fix: update landing page links

### DIFF
--- a/apis_ontology/templates/base.html
+++ b/apis_ontology/templates/base.html
@@ -54,7 +54,8 @@ TibSchol: The Dawn of Tibetan Buddhist Scholasticism (11th–13th c.)
             </div>
             <div class="container-fluid">
                 <p>
-                    <strong>TibSchol</strong> explores the formative phase of the Tibetan Buddhist scholastic tradition
+                    <a target="_blank" href="https://www.oeaw.ac.at/projects/tibschol/home"><strong>TibSchol</strong></a> explores the formative
+                        phase of the Tibetan Buddhist scholastic tradition
                     in the 11th to 13th century—an exceptionally active period of Tibetan scholarly creativity.
                 </p>
                 <p>
@@ -64,8 +65,7 @@ TibSchol: The Dawn of Tibetan Buddhist Scholasticism (11th–13th c.)
                 </p>
                 <p>
                     This prosopographical database contains the data collected by the <a target="_blank"
-                        href="https://www.oeaw.ac.at/projects/tibschol/home">TibSchol project</a> <a target="_blank"
-                        href="https://www.oeaw.ac.at/projects/tibschol/people">team</a> with the aim
+                        href="https://www.oeaw.ac.at/projects/tibschol/people">TibSchol project team</a> with the aim
                     of answering such questions—and more—in order to contribute to a more comprehensive and dynamic
                     picture of the Tibetan scholastic landscape, with a focus on the 11th to 13th centuries. More
                     generally, it seeks to offer a better-grounded and more nuanced understanding of Tibetan
@@ -93,12 +93,13 @@ TibSchol: The Dawn of Tibetan Buddhist Scholasticism (11th–13th c.)
                     platform to accommodate TibSchol’s <a href="https://erc-tibschol.github.io/datamodel/" target="_blank"> data
                         model</a>. It
                     is linked to the <a href="https://www.zotero.org/" target="_blank">Zotero</a> group library <a href="
-                                                                        https://www.zotero.org/groups/4394244/tibschol"
+                                                                                        https://www.zotero.org/groups/4394244/tibschol"
                         target="_blank">“TibSchol”</a>,
                     which
                     provides metadata for cited sources and
-                    relation support, and to a TEI repository of textual <a href="https://github.com/ERC-TibSchol/excerpts-extractor/"
-                        target="_blank">excerpts</a>, both of which are also
+                    relation support, and to a TEI repository of textual <a
+                        href="https://github.com/ERC-TibSchol/Data-Sets-TEIs-Database-" target="_blank">excerpts</a>, both of which are
+                    also
                         accessible independently.
                 </p>
                 <p>


### PR DESCRIPTION
based on feedback:
just "Tibschol" - in bold - should be linked to https://www.oeaw.ac.at/projects/tibschol/project and tibschol project team to Link
https://www.oeaw.ac.at/projects/tibschol/people as a whole (not Tibschol + project team) and "excerpts" should be linked to the public repository, not to the extractor tool