### PR TITLE
feat: export-relations as json

### DIFF
--- a/apis_ontology/export_utils.py
+++ b/apis_ontology/export_utils.py
@@ -1,0 +1,56 @@
+from apis_core.relations.models import Relation
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class TibScholDataExport:
+    @staticmethod
+    def all_relations():
+        """
+        Export relations data in JSON format.
+        This method should be implemented to gather the necessary data.
+        """
+
+        def get_label(entity):
+            try:
+                return entity.name
+            except AttributeError:
+                try:
+                    return entity.label
+                except AttributeError:
+                    pass
+
+            return str(entity)
+
+        relation_data = []
+        qs = Relation.objects.select_subclasses().order_by("id")
+
+        for rel in Relation.objects.select_subclasses():
+            try:
+                relation_data.append(
+                    {
+                        "source_type": rel.subj.__class__.__name__.lower(),
+                        "source": rel.subj.id,
+                        "source_label": get_label(rel.subj),
+                        "target_type": rel.obj.__class__.__name__.lower(),
+                        "target": rel.obj.id,
+                        "target_label": get_label(rel.obj),
+                        "forward": rel.name(),
+                        "reverse": rel.reverse_name(),
+                        "confidence": rel.confidence,
+                        "start": rel.start,
+                        "end": rel.end,
+                        "topic": rel.topic if hasattr(rel, "topic") else "",
+                    }
+                )
+            except Exception as e:
+                logger.error(
+                    "Error processing relation %s: %s",
+                    rel.id,
+                    e,
+                    exc_info=True,
+                )
+
+        print(f"Exported {len(relation_data)} relations")
+        return relation_data

--- a/apis_ontology/urls.py
+++ b/apis_ontology/urls.py
@@ -1,4 +1,4 @@
-from apis_ontology.views import DataModelView, ExcerptsView
+from apis_ontology.views import DataModelView, ExcerptsView, ExportRelationsJSONView
 from django.contrib import admin
 from django.urls import include, path
 from django.views.generic import TemplateView
@@ -24,6 +24,11 @@ urlpatterns = [
         "apis/datamodel/",
         DataModelView.as_view(),
         name="datamodel",
+    ),
+    path(
+        "apis/export-relations-json/",
+        ExportRelationsJSONView.as_view(),
+        name="relations.json",
     ),
 ]
 

--- a/apis_ontology/views.py
+++ b/apis_ontology/views.py
@@ -4,10 +4,10 @@ from django.shortcuts import get_object_or_404
 from django.views.generic.base import TemplateView
 from .models import Excerpts, Instance
 from .data_model_utils import DataModel
+from .export_utils import TibScholDataExport
 
 
 class ExcerptsView(View):
-
     def get(self, request, xml_id, render_style, *args, **kwargs):
         def get_instances_from_tibschol_refs(tibschol_refs):
             instances = []
@@ -45,3 +45,9 @@ class DataModelView(TemplateView):
         ctx = super().get_context_data()
         ctx["datamodel"] = DataModel()
         return ctx
+
+
+class ExportRelationsJSONView(View):
+    def get(self, request, *args, **kwargs):
+        data = TibScholDataExport.all_relations()
+        return JsonResponse(data, safe=False)


### PR DESCRIPTION
This pull request introduces functionality to export relation data in JSON format and integrates it into the API. The changes include adding a new utility class for data export, creating a corresponding view, and updating the URL configuration to expose the new endpoint.

### New functionality for exporting relations:

* [`apis_ontology/export_utils.py`](diffhunk://#diff-55ae1480d117a1431cf2f641dd5e54b6a877840a2e3a9b83283034127e68332eR1-R56): Added a `TibScholDataExport` class with a static method `all_relations()` to export relation data in JSON format. The method handles various attributes of relations and logs errors encountered during processing.

### Integration with the API:

* [`apis_ontology/views.py`](diffhunk://#diff-6288409a4037e048fa138cacd118a2f0ac6c526f0f549209c0c1b106c4d1f5b4R48-R53): Introduced a new view `ExportRelationsJSONView` that uses the `TibScholDataExport.all_relations()` method to return the exported data as a JSON response.
* [`apis_ontology/urls.py`](diffhunk://#diff-f4051c017f27901a819ed4f672fc890dbc5d9cf69c4579c85680f109ca3902c2R28-R32): Added a new URL pattern `/apis/export-relations-json/` to expose the `ExportRelationsJSONView` endpoint.

### Supporting changes:

* [`apis_ontology/urls.py`](diffhunk://#diff-f4051c017f27901a819ed4f672fc890dbc5d9cf69c4579c85680f109ca3902c2L1-R1): Updated imports to include the new `ExportRelationsJSONView`.
* [`apis_ontology/views.py`](diffhunk://#diff-6288409a4037e048fa138cacd118a2f0ac6c526f0f549209c0c1b106c4d1f5b4R7-L10): Imported the `TibScholDataExport` class to be used in the new view.