### PR TITLE
feat(datamodel): sort the relations inside cells

### DIFF
--- a/apis_ontology/data_model_utils.py
+++ b/apis_ontology/data_model_utils.py
@@ -60,6 +60,6 @@ class DataModel:
             )
 
         # sort the relations
-        # for row in self.matrix:
-        #     for col in self.matrix[row]:
-        #         self.matrix[row][col] = sorted(set(self.matrix[row][col]))
+        for subj in self.matrix:
+            for obj in self.matrix[subj]:
+                self.matrix[subj][obj].sort(key=lambda x: x["display"])


### PR DESCRIPTION
This pull request updates the sorting logic for relations in the `__init__` method of `apis_ontology/data_model_utils.py`. The change replaces commented-out code with an active implementation that sorts the relations based on the `"display"` key.

* [`apis_ontology/data_model_utils.py`](diffhunk://#diff-6d13208f0f0f94e3edcfc5547b924dfaf43c2d9478a15fb3216e3d3c005b1bcaL63-R65): Updated the `__init__` method to sort relations in `self.matrix` by the `"display"` key using a lambda function.