### PR TITLE
feat(tables): add works column to Topic table

### DIFF
--- a/apis_ontology/tables.py
+++ b/apis_ontology/tables.py
@@ -987,3 +987,33 @@ class ZoteroEntryTable(GenericTable):
 
     def render_zoteroId(self, value):
         return value
+
+
+class SubjectTable(GenericTable):
+    class Meta(GenericTable.Meta):
+        exclude = [
+            "id",
+            "desc",
+            "view",
+        ]
+        fields = ["name"]
+        sequence = ("name", "...", "edit", "delete")
+
+    works = tables.Column(orderable=False, verbose_name="Works", accessor="pk")
+
+    def value_works(self, value):
+        works = Work.objects.filter(subject_vocab=value)
+        return render_list_field("\n".join([str(w) for w in works]))
+
+    def render_works(self, value):
+        works = Work.objects.filter(subject_vocab=value)
+        return mark_safe(
+            render_list_field(
+                "\n".join(
+                    [
+                        f"<a href='{w.get_absolute_url()}' target='_blank'>{str(w)}</a>"
+                        for w in works
+                    ]
+                )
+            )
+        )


### PR DESCRIPTION
This pull request introduces a new `SubjectTable` class to the `apis_ontology/tables.py` file, which extends the functionality of the `GenericTable` class. The most important changes include defining the metadata for the table, adding a custom column for displaying related works, and implementing methods to render and format the works column.

### Addition of `SubjectTable` class:
* **Metadata definition:** The `Meta` subclass specifies fields to exclude (`id`, `desc`, `view`), fields to include (`name`), and the sequence of fields (`name`, followed by others, and ending with `edit` and `delete`). (`[apis_ontology/tables.pyR990-R1019](diffhunk://#diff-2ff430a2f96c033674f5795bd02c89280acef6d6b3e3d755ec2456e5e12b4b54R990-R1019)`)
* **Custom column for works:** A non-orderable column `works` is added with a verbose name "Works" and an accessor for the primary key (`pk`). (`[apis_ontology/tables.pyR990-R1019](diffhunk://#diff-2ff430a2f96c033674f5795bd02c89280acef6d6b3e3d755ec2456e5e12b4b54R990-R1019)`)

### Rendering and formatting of works:
* **`value_works` method:** Retrieves related `Work` objects filtered by `subject_vocab` and formats them into a list. (`[apis_ontology/tables.pyR990-R1019](diffhunk://#diff-2ff430a2f96c033674f5795bd02c89280acef6d6b3e3d755ec2456e5e12b4b54R990-R1019)`)
* **`render_works` method:** Renders the related `Work` objects as clickable links pointing to their absolute URLs, using HTML formatting. (`[apis_ontology/tables.pyR990-R1019](diffhunk://#diff-2ff430a2f96c033674f5795bd02c89280acef6d6b3e3d755ec2456e5e12b4b54R990-R1019)`)