### PR TITLE
fix (excerpts): bring back modal dialog

### DIFF
--- a/apis_ontology/static/styles/tibschol.css
+++ b/apis_ontology/static/styles/tibschol.css
@@ -39,7 +39,9 @@ pre#rawTEI{
   line-break: anywhere;
   margin-left: 2em;
 }
-
+#modal .modal-dialog {
+    max-width: 800px;
+}
 .modal-content{
      max-height: 90vh;
     overflow-y: auto;

--- a/apis_ontology/templates/base.html
+++ b/apis_ontology/templates/base.html
@@ -38,12 +38,9 @@ TibSchol: The Dawn of Tibetan Buddhist Scholasticism (11th–13th c.)
     </div>
 </li>
 {{ block.super }}
+{% include "excerpts/excerpts.html" %}
 {% endblock main-menu %}
 
-{% block modal %}
-{{ block.super }}
-{% include "excerpts/excerpts.html" %}
-{% endblock modal %}
 
 {% block content %}
     <div class="container my-5">


### PR DESCRIPTION
Urgent fix to put modal block back in for previewing excerpts as https://github.com/acdh-oeaw/apis-core-rdf/pull/1918 removed it from the base template

Closing #461 will eventually get rid of this hack
