### PR TITLE
chore(deps): update core to 49.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
     "psycopg2==2.9.*",
-    "apis-core-rdf==0.49.0",
+    "apis-core-rdf==0.49.1",
     "apis-acdhch-default-settings==2.10.0",
     "django-extensions==4.1.*",
     "tqdm==4.67.1",


### PR DESCRIPTION
This pull request includes a minor update to the `pyproject.toml` file to upgrade the `apis-core-rdf` dependency to version `0.49.1`.