### PR TITLE
deps: remove django-select2

### DIFF
--- a/apis_ontology/settings/server_settings.py
+++ b/apis_ontology/settings/server_settings.py
@@ -19,7 +19,6 @@ CSRF_TRUSTED_ORIGINS = [
 
 INSTALLED_APPS += [
     "django.contrib.postgres",
-    "django_select2",
     "django_interval",
 ]
 INSTALLED_APPS.append("apis_core.documentation")
@@ -52,13 +51,8 @@ CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
     },
-    "select2": {
-        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
-        "TIMEOUT": 60 * 60 * 24,  # Timeout set to 1 day (in seconds)
-    },
 }
 
-SELECT2_CACHE_BACKEND = "select2"
 
 MIDDLEWARE += [
     "simple_history.middleware.HistoryRequestMiddleware",

--- a/apis_ontology/urls.py
+++ b/apis_ontology/urls.py
@@ -34,9 +34,6 @@ urlpatterns = [
 
 urlpatterns += staticfiles_urlpatterns()
 
-urlpatterns += [
-    path("select2/", include("django_select2.urls")),
-]
 
 urlpatterns += [path("", include("django_interval.urls"))]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,12 +13,11 @@ dependencies = [
     "django-extensions==4.1.*",
     "tqdm==4.67.1",
     "pandas==2.2.3",
-    "django-select2==8.2.3",
     "tablib[xlsx]==3.8.0",
     "lxml==5.3.1",
     "django-interval==0.5.1",
     "django-debug-toolbar==5.1.0",
-    "tabulate==0.9.0"
+    "tabulate==0.9.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This pull request removes the `django-select2` dependency and its associated configurations and URLs from the project. 

### Removal of `django-select2` dependency and related configurations:

* [`apis_ontology/settings/server_settings.py`](diffhunk://#diff-2903b7820ed1f17f3d8fa1eee95d7bba39d40c18f6810445aa4f3fdfa84636baL22): Removed `django_select2` from `INSTALLED_APPS` and deleted its associated cache configuration (`select2` cache backend and `SELECT2_CACHE_BACKEND` setting). [[1]](diffhunk://#diff-2903b7820ed1f17f3d8fa1eee95d7bba39d40c18f6810445aa4f3fdfa84636baL22) [[2]](diffhunk://#diff-2903b7820ed1f17f3d8fa1eee95d7bba39d40c18f6810445aa4f3fdfa84636baL55-L61)
* [`apis_ontology/urls.py`](diffhunk://#diff-f4051c017f27901a819ed4f672fc890dbc5d9cf69c4579c85680f109ca3902c2L37-L39): Removed the URL pattern for `django_select2` by deleting the `path("select2/", include("django_select2.urls"))` entry.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L16-R20): Removed `django-select2==8.2.3` from the project dependencies.