### PR TITLE
fix: handles when excerpt ids are enclosed with parantheses

### DIFF
--- a/apis_ontology/templatetags/render_tei_refs.py
+++ b/apis_ontology/templatetags/render_tei_refs.py
@@ -1,6 +1,6 @@
 import logging
 import re
-
+import string
 
 from apis_core.apis_metainfo.models import RootObject
 from apis_ontology.models import ZoteroEntry
@@ -19,7 +19,8 @@ def render_tei_refs(value):
 
     def linkify_excerpt_id(xml_id):
         true_id = xml_id.replace('"', "").replace("xml:id=", "").strip().rstrip(".")
-        return f"""<a href='#' onclick="showExcerpt('{true_id}'); return false;">{true_id}</a>"""
+        true_id_without_punctuation = xml_id.strip(string.punctuation)
+        return f"""<a href='#' onclick="showExcerpt('{true_id_without_punctuation}'); return false;">{true_id}</a>"""
 
     if not value.strip():
         return ""


### PR DESCRIPTION
or immediately followed by any punctuation

closes #453

This pull request introduces a minor enhancement to the `render_tei_refs.py` file by improving the handling of XML IDs in the `linkify_excerpt_id` function. The change ensures that punctuation is stripped from the XML ID before generating the link.

Key changes:

### Code improvement for XML ID processing:
* [`apis_ontology/templatetags/render_tei_refs.py`](diffhunk://#diff-86e8ee9c21d358157ffa72d9b9dbd738c221ee01e1044883255f24d9ba7a92cfL3-R3): Added the `string` library import to facilitate stripping punctuation from XML IDs.
* [`apis_ontology/templatetags/render_tei_refs.py`](diffhunk://#diff-86e8ee9c21d358157ffa72d9b9dbd738c221ee01e1044883255f24d9ba7a92cfL22-R23): Updated the `linkify_excerpt_id` function to strip punctuation from the `xml_id` before generating the link, improving the reliability of the `true_id` used in the link.