### PR TITLE
fix: force language to en in data model page

### DIFF
--- a/apis_ontology/templates/datamodel.html
+++ b/apis_ontology/templates/datamodel.html
@@ -6,6 +6,7 @@
 {% load parse_comment %}
 
 {% block content %}
+{% language 'en' %}
 <div class="container text-center  mb-auto" id="top">
     <h2 class="">Entities and Relations</h2>
     <table border="1" class=" align-middle table table-bordered table-striped table-hover">
@@ -74,4 +75,5 @@
         {% endfor %}
     </div>
 </div>
+{% endlanguage %}
 {% endblock content %}


### PR DESCRIPTION
This pull request introduces a minor update to the `apis_ontology/templates/datamodel.html` template to improve language handling for the page content.

* Added `{% language 'en' %}` and `{% endlanguage %}` template tags to explicitly set the language context for the "Entities and Relations" section,  as terminology and descriptions are available only in english at the moment.  [[1]](diffhunk://#diff-c627700e6ae18ad45b600383242cc6b6ee1b0fee130f2c931d1781c07f1db5b6R9) [[2]](diffhunk://#diff-c627700e6ae18ad45b600383242cc6b6ee1b0fee130f2c931d1781c07f1db5b6R78)