### PR TITLE
feat: avoid repeating reverse relation…

### DIFF
--- a/apis_ontology/models.py
+++ b/apis_ontology/models.py
@@ -427,6 +427,15 @@ class TibScholRelationMixin(VersionMixin, Relation, GenericModel):
     start = FuzzyDateParserField(parser=tibschol_dateparser, null=True, blank=True)
     end = FuzzyDateParserField(parser=tibschol_dateparser, null=True, blank=True)
 
+    @classmethod
+    def relation_name(cls) -> str:
+        """Returns the name and reverse_name
+        of the relation as defined in the subclass
+        if they are different, else just the name."""
+        if cls.name() != cls.reverse_name():
+            return f"{cls.name()} - {cls.reverse_name()}"
+        return cls.name()
+
     @property
     def subject_type(self):
         return str(self.subj_model.__name__).lower()

--- a/apis_ontology/templates/base.html
+++ b/apis_ontology/templates/base.html
@@ -43,7 +43,7 @@ TibSchol: The Dawn of Tibetan Buddhist Scholasticism (11th–13th c.)
             {% get_relation_content_types as content_types %}
             {% for content_type in content_types %}
             <a class="dropdown-item relation-item" href="{{ content_type.model_class.get_listview_url }}">
-                {{ content_type.model_class.name }} – {{ content_type.model_class.reverse_name }}
+                {{ content_type.model_class.relation_name }}
             </a>
             {% endfor %}
         </div>


### PR DESCRIPTION
if it is identical to the forward name

This pull request introduces a small but meaningful improvement to how relation names are displayed in the UI and provided in the model. The main change is the addition of a new `relation_name` class method to the `TibScholRelationMixin` model, which generates a more user-friendly representation of relation names, especially when the name and reverse name differ.

Model enhancement:

* Added a `relation_name` class method to `TibScholRelationMixin` in `apis_ontology/models.py`, which returns either the combined name and reverse name (if they differ) or just the name.

UI improvement:

* Updated the relation dropdown in `apis_ontology/templates/base.html` to use the new `relation_name` method for displaying relation names, ensuring consistency and clarity in the UI.