### PR TITLE
fix: inherit meta class in search form

### DIFF
--- a/apis_ontology/forms.py
+++ b/apis_ontology/forms.py
@@ -92,7 +92,9 @@ class InstanceForm(TibscholEntityForm):
     ]
 
 
-class TibScholEntityMixinSearchForm(GenericFilterSetForm):
+class TibScholEntityMixinSearchForm(
+    GenericFilterSetForm, metaclass=GenericFilterSetForm.Meta
+):
     columns_exclude = [
         "start_date_from",
         "end_date_from",


### PR DESCRIPTION
This pull request updates the `TibScholEntityMixinSearchForm` class in `apis_ontology/forms.py` to improve its inheritance structure by explicitly setting its metaclass. This change helps ensure that the form leverages the correct meta behavior from `GenericFilterSetForm`.

* Refactored `TibScholEntityMixinSearchForm` to inherit the metaclass from `GenericFilterSetForm` by specifying `metaclass=GenericFilterSetForm.Meta`, improving form initialization and meta handling.