### PR TITLE
fix(entities): remove non-existant metaclass from search form

### DIFF
--- a/apis_ontology/forms.py
+++ b/apis_ontology/forms.py
@@ -92,9 +92,7 @@ class InstanceForm(TibscholEntityForm):
     ]
 
 
-class TibScholEntityMixinSearchForm(
-    GenericFilterSetForm, metaclass=GenericFilterSetForm.Meta
-):
+class TibScholEntityMixinSearchForm(GenericFilterSetForm):
     columns_exclude = [
         "start_date_from",
         "end_date_from",


### PR DESCRIPTION
This pull request makes a minor change to the `TibScholEntityMixinSearchForm` class in `apis_ontology/forms.py`. The metaclass assignment to `GenericFilterSetForm.Meta` has been removed.