### PR TITLE
ci: switch from bash to sh for the cronjob command

### DIFF
--- a/.github/auto-deploy-values.yaml
+++ b/.github/auto-deploy-values.yaml
@@ -46,7 +46,7 @@ readinessProbe:
 cronjobs:
   zotero:
     schedule:  "0 4 * * *"
-    command: ["/bin/bash"]
+    command: ["/bin/sh"]
     args: ["-c", "python manage.py fetch_zotero_entries"]
     image:
       repository: $repository
@@ -55,7 +55,7 @@ cronjobs:
 
   excerpts:
     schedule: '0 6,13,18,23 * * *'
-    command: ["/bin/bash"]
+    command: ["/bin/sh"]
     args: ["-c", "python manage.py import_excerpts && python manage.py excerpts-in-use-collection"]
     image:
       repository: $repository


### PR DESCRIPTION
This pull request makes a minor update to the cronjob configuration in `.github/auto-deploy-values.yaml`, switching the shell used to run commands from `/bin/bash` to `/bin/sh` for both the `zotero` and `excerpts` jobs. This change ensures better compatibility with minimal container images that may not include Bash.

* Changed the `command` for the `zotero` cronjob from `/bin/bash` to `/bin/sh` to improve shell compatibility.
* Changed the `command` for the `excerpts` cronjob from `/bin/bash` to `/bin/sh` for the same reason.