### PR TITLE
feat(excerpts): show excerpts with an icon link

### DIFF
--- a/apis_ontology/templatetags/render_tei_refs.py
+++ b/apis_ontology/templatetags/render_tei_refs.py
@@ -20,7 +20,7 @@ def render_tei_refs(value):
     def linkify_excerpt_id(xml_id):
         true_id = xml_id.replace('"', "").replace("xml:id=", "").strip().rstrip(".")
         true_id_without_punctuation = xml_id.strip(string.punctuation)
-        return f"""<a href='#' onclick="showExcerpt('{true_id_without_punctuation}'); return false;">{true_id}</a>"""
+        return f"""<a title='{true_id}' class='align-text-top' href='#' onclick="showExcerpt('{true_id_without_punctuation}'); return false;"><span class="material-symbols-outlined">text_snippet</span></a>"""
 
     if not value.strip():
         return ""


### PR DESCRIPTION
closes #526

This pull request updates the rendering of TEI references to improve their appearance and usability in the UI.

UI enhancements for TEI reference links:

* Updated the `linkify_excerpt_id` function in `render_tei_refs.py` to display TEI references as icon buttons using a Material Symbol, added a tooltip with the reference ID, and applied the `align-text-top` CSS class for better alignment.