### PR TITLE
fix(excerpts): render TEI even when TibSchol ref is empty

### DIFF
--- a/apis_ontology/views.py
+++ b/apis_ontology/views.py
@@ -10,6 +10,7 @@ from .export_utils import TibScholDataExport
 class ExcerptsView(View):
     def get(self, request, xml_id, render_style, *args, **kwargs):
         def get_instances_from_tibschol_refs(tibschol_refs):
+            tibschol_refs = tibschol_refs.strip()
             instances = []
             for tibschol_ref in tibschol_refs.split("\n"):
                 try:


### PR DESCRIPTION
addresses #526 

This pull request contains a minor update to the `ExcerptsView` class in `apis_ontology/views.py`. The change ensures that any leading or trailing whitespace is removed from the `tibschol_refs` string before it is processed. This helps prevent errors when splitting and iterating over the references.