### PR TITLE
fix: add additional material icons

### DIFF
--- a/apis_ontology/static/styles/tibschol.css
+++ b/apis_ontology/static/styles/tibschol.css
@@ -54,3 +54,28 @@ pre#rawTEI{
 .relation-confidence{
   vertical-align: middle;
 }
+
+
+/* extra material icons */
+@font-face {
+  font-family: 'Material Symbols Outlined';
+  font-style: normal;
+  font-weight: 400;
+  src: url(https://fonts.gstatic.com/icon/font?kit=kJF1BvYX7BgnkSrUwT8OhrdQw4oELdPIeeII9v6oDMzByHX9rA6RzaxHMPdY43zj-jCxv3fzvRNU22ZXGJpEpjC_1v-p_4MrImHCIJIZrDCvHOejdc4kzUJPvbBw9tiQ8cGhE_4rdSZGCM-PGZ6qg-4xjNUlZ8yWR9ebLW1-Sg8&skey=b8dc2088854b122f&v=v292) format('woff2');
+}
+
+.material-symbols-outlined {
+  font-family: 'Material Symbols Outlined';
+  font-weight: normal;
+  font-style: normal;
+  font-size: 24px;
+  line-height: 1;
+  letter-spacing: normal;
+  text-transform: none;
+  display: inline-block;
+  white-space: nowrap;
+  word-wrap: normal;
+  direction: ltr;
+  -webkit-font-feature-settings: 'liga';
+  -webkit-font-smoothing: antialiased;
+}


### PR DESCRIPTION
This pull request adds support for Material Symbols Outlined icons to the `apis_ontology/static/styles/tibschol.css` stylesheet. The most important change is the inclusion of the necessary font-face definition and styling rules to enable the use of these icons in the application.

**Material icon support:**

* Added `@font-face` definition for the 'Material Symbols Outlined' font, loading it from a Google Fonts URL.
* Added `.material-symbols-outlined` CSS class with styling to display Material Symbols Outlined icons consistently.