### PR TITLE
fix: remove duplicate column from relation list views

### DIFF
--- a/apis_ontology/tables.py
+++ b/apis_ontology/tables.py
@@ -472,7 +472,7 @@ class TibScholRelationMixinTable(GenericTable):
 
     class Meta(GenericTable.Meta):
         fields = ["subj", "obj"]
-        exclude = ["desc", "view", "edit", "delete"]
+        exclude = ["desc", "view", "edit", "delete", "noduplicate"]
         sequence = ("subj", "obj", "...")
 
     subj = tables.Column(verbose_name="Subject")


### PR DESCRIPTION
This pull request makes a small adjustment to the configuration of the `TibScholRelationMixinTable` class in `apis_ontology/tables.py`. The change updates the list of excluded fields in the table's metadata.

* Added `noduplicate` to the `exclude` list in the `Meta` class of `TibScholRelationMixinTable`, ensuring that this field does not appear in the table view.