### PR TITLE
fix: relations table in detail page

### DIFF
--- a/apis_ontology/tables.py
+++ b/apis_ontology/tables.py
@@ -346,7 +346,7 @@ class TibScholEntityMixinRelationsTable(GenericTable):
     )
 
     class Meta(GenericTable.Meta):
-        exclude = ["desc"]
+        exclude = ["desc", "noduplicate"]
         per_page = 1000
         sequence = (
             "relation",

--- a/apis_ontology/templatetags/render_tei_refs.py
+++ b/apis_ontology/templatetags/render_tei_refs.py
@@ -41,4 +41,4 @@ def render_tei_refs(value):
 
         linked_lines.append(" ".join(linked_words))
 
-    return "<br />".join(linked_lines) + "<br />" if len(linked_lines) else ""
+    return ", ".join(linked_lines) + "<br />" if len(linked_lines) else ""


### PR DESCRIPTION
This pull request introduces minor improvements to both table configuration and excerpt rendering. The most notable changes are an update to the exclusion list in the `TibScholEntityMixinRelationsTable` and a change to the output format in the `linkify_excerpt_id` function.

Table configuration:

* Updated the `exclude` list in the `Meta` class of `TibScholEntityMixinRelationsTable` to also exclude `noduplicate`, improving control over displayed fields.

Excerpt rendering:

* Changed the output separator in `linkify_excerpt_id` from `<br />` to a comma, resulting in a more compact and readable format for linked lines.

closes #532 