### PR TITLE
removes inadvertent removal of linebreaks while rendering comments

### DIFF
--- a/apis_ontology/tables.py
+++ b/apis_ontology/tables.py
@@ -337,6 +337,11 @@ class TibScholEntityMixinRelationsTable(GenericTable):
         preview=lambda x: "",
         fulltext=lambda x: mark_safe(
             render_tei_refs(getattr(x, "tei_refs", "") or "")
+            .replace("<br />", ", ")
+            .rstrip(", ")
+            + "<br />"
+            if getattr(x, "tei_refs", "")
+            else ""
             + parse_comment(
                 render_list_field(
                     f"{getattr(x,'support_notes', '') or ''}\n{getattr(x, 'zotero_refs','')  or ''}",

--- a/apis_ontology/templatetags/render_tei_refs.py
+++ b/apis_ontology/templatetags/render_tei_refs.py
@@ -41,4 +41,4 @@ def render_tei_refs(value):
 
         linked_lines.append(" ".join(linked_words))
 
-    return ", ".join(linked_lines) + "<br />" if len(linked_lines) else ""
+    return "<br />".join(linked_lines) + "<br />" if len(linked_lines) else ""


### PR DESCRIPTION
whilst preserving a more compact representation of excerpts in the support for relations

fixes #544

