### PR TITLE
feat(works): show unknown extant status as unknown…

### DIFF
--- a/apis_ontology/templates/apis_ontology/work_card_table.html
+++ b/apis_ontology/templates/apis_ontology/work_card_table.html
@@ -51,7 +51,11 @@
     {% endif %}
     <tr>
         <th>Is extant</th>
-        <td>{{ object.isExtant }}</td>
+        <td>
+            {% if object.isExtant is None %}Unknown
+            {% else %}{{ object.isExtant }}
+            {% endif %}
+        </td>
     </tr>
 
     {% if object.comments %}


### PR DESCRIPTION
instead of None

fixes #549


This pull request makes a small improvement to how the `isExtant` field is displayed in the `work_card_table.html` template. Now, if the value is `None`, it will show "Unknown" instead of None.
