### PR TITLE
fix: clean excerpt id to preview excerpt correctly

### DIFF
--- a/apis_ontology/templatetags/render_tei_refs.py
+++ b/apis_ontology/templatetags/render_tei_refs.py
@@ -19,7 +19,7 @@ def render_tei_refs(value):
 
     def linkify_excerpt_id(xml_id):
         true_id = xml_id.replace('"', "").replace("xml:id=", "").strip().rstrip(".")
-        true_id_without_punctuation = xml_id.strip(string.punctuation)
+        true_id_without_punctuation = true_id.strip(string.punctuation)
         return f"""<a title='{true_id}' class='align-text-top' href='#' onclick="showExcerpt('{true_id_without_punctuation}'); return false;"><span class="material-symbols-outlined">text_snippet</span></a>"""
 
     if not value.strip():


### PR DESCRIPTION
fixes #548 

This pull request fixes a minor bug in the `render_tei_refs.py` template tag by ensuring that punctuation is correctly stripped from the processed XML ID before generating the link. This improves the accuracy of the excerpt reference links.

* Fixed the logic in `linkify_excerpt_id` to use the cleaned `true_id` value when stripping punctuation, rather than the original `xml_id`, ensuring the generated link references are correct.