### PR TITLE
fix: show TEI references, support notes and Zotero refs

### DIFF
--- a/apis_ontology/tables.py
+++ b/apis_ontology/tables.py
@@ -336,12 +336,14 @@ class TibScholEntityMixinRelationsTable(GenericTable):
         orderable=False,
         preview=lambda x: "",
         fulltext=lambda x: mark_safe(
-            render_tei_refs(getattr(x, "tei_refs", "") or "")
-            .replace("<br />", ", ")
-            .rstrip(", ")
-            + "<br />"
-            if getattr(x, "tei_refs", "")
-            else ""
+            (
+                render_tei_refs(getattr(x, "tei_refs", "") or "")
+                .replace("<br />", ", ")
+                .rstrip(", ")
+                + "<br />"
+                if getattr(x, "tei_refs")
+                else ""
+            )
             + parse_comment(
                 render_list_field(
                     f"{getattr(x,'support_notes', '') or ''}\n{getattr(x, 'zotero_refs','')  or ''}",


### PR DESCRIPTION
fixes #558

This pull request makes a minor update to the `TibScholEntityMixinRelationsTable` class in `apis_ontology/tables.py`. The change improves the logic for rendering the `fulltext` field, ensuring that a line break is only added when `tei_refs` is present, which could help prevent unnecessary HTML output.

- Improved the `fulltext` lambda function to only append a line break if `tei_refs` is present, making the output cleaner and more accurate.