### PR TITLE
fix: pin django-tables2 to 2.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "django-interval==0.5.4",
     "django-debug-toolbar==6.2.0",
     "tabulate==0.10.0",
+    "django-tables2==2.8",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Breaking change in django-tables2 from [2.8 to 2.9](https://github.com/jieter/django-tables2/compare/v2.8.0...v2.9.0#diff-112d7cd445c59ef34d3622ea5d215a55eaa302055132f19b4ea2ebef60e70b54)

TemplateColumn.render signature changed from
`def render(self, record, table, value, bound_column, **kwargs):` to `def render(self, table, **kwargs):`