### PR TITLE
Custom columns tibetan

### DIFF
--- a/apis_ontology/tables.py
+++ b/apis_ontology/tables.py
@@ -155,10 +155,9 @@ class AuthorColumn(tables.Column):
             try:
                 author = Person.objects.get(pk=getattr(subj_work, "author_id"))
                 context = {
-                    "entity_id": author.pk,
-                    "entity_name": author.name,
-                    "entity_uri": author.get_absolute_url(),
+                    "entity": author,
                 }
+                print(render_to_string("apis_ontology/linked_entity_column.html", context))
                 return mark_safe(
                     render_to_string("apis_ontology/linked_entity_column.html", context)
                 )
@@ -379,15 +378,8 @@ class EntityRelationAuthorColumn(CustomTemplateColumn):
         if getattr(subj_work, "author_id"):
             try:
                 author = Person.objects.get(pk=getattr(subj_work, "author_id"))
-                author_uri = None
-                if (record.forward and record.subj_object_id != author.pk) or (
-                    not record.forward and record.obj_object_id != author.pk
-                ):
-                    author_uri = author.get_absolute_url()
                 self.extra_context = {
-                    "entity_id": author.pk,
-                    "entity_name": author.name,
-                    "entity_uri": author_uri,
+                    "entity": author,
                 }
                 return super().render(author, **kwargs)
 

--- a/apis_ontology/tables.py
+++ b/apis_ontology/tables.py
@@ -132,7 +132,18 @@ class PersonDateColumn(tables.Column):
         return queryset, True
 
 
-class AuthorColumn(tables.Column):
+class AuthorColumn(CustomTemplateColumn):
+    template_name = "apis_ontology/linked_entity_column.html"
+    def __init__(self, *args, **kwargs):
+        self.orderable = kwargs.get("orderable", False)
+        self.verbose_name = kwargs.get("verbose_name", None)
+        kwargs.pop("orderable", None)
+        kwargs.pop("verbose_name", None)    
+        super().__init__(
+            *args,
+            **kwargs,
+        )
+
     @classmethod
     def get_work_from_id(cls, work_instance_id):
         try:
@@ -147,27 +158,24 @@ class AuthorColumn(tables.Column):
                     work_instance_id,
                 )
 
-    def render(self, value, *args, **kwargs):
+    def render(self, record,table, value, *args, **kwargs):
         subj_work = self.__class__.get_work_from_id(value)
         if not subj_work:
             return ""
         if getattr(subj_work, "author_id"):
             try:
                 author = Person.objects.get(pk=getattr(subj_work, "author_id"))
-                context = {
+                self.extra_context = {
                     "entity": author,
                 }
-                print(render_to_string("apis_ontology/linked_entity_column.html", context))
-                return mark_safe(
-                    render_to_string("apis_ontology/linked_entity_column.html", context)
-                )
+                return super().render(record, table, author, **kwargs)
             except Person.DoesNotExist:
                 # Author is deleted or not accessible to the user
                 logger.warning("Unable to find author for %s ", subj_work)
 
         return ""
 
-    def value(self, value, *args, **kwargs):
+    def value(self,record, table, value, *args, **kwargs):
         work = self.get_work_from_id(value)
         if not work:
             return ""
@@ -460,7 +468,27 @@ class TibScholEntityMixinPersonRelationsTable(TibScholEntityMixinRelationsTable)
     class Meta(TibScholEntityMixinRelationsTable.Meta):
         pass
 
+class LinkedEntityColumn(CustomTemplateColumn):
+    template_name = "apis_ontology/linked_entity_column.html"
+    orderable = True
 
+    def __init__(self, *args, **kwargs):
+        if "verbose_name" in kwargs:
+            self.verbose_name = kwargs.pop("verbose_name")
+        if "orderable" in kwargs:
+            self.orderable = kwargs.pop("orderable")
+        
+        super().__init__(*args, **kwargs)
+
+    def render(self, record, *args, **kwargs):
+        self.extra_context = {
+            "entity": getattr(record, str(self.accessor), None),
+        }
+        return super().render(record,*args,**kwargs)
+
+
+        return super().render(record, table, value, bound_column, **kwargs) 
+    
 class TibScholRelationMixinTable(GenericTable):
     paginate_by = 100
     export_filename = (
@@ -472,8 +500,8 @@ class TibScholRelationMixinTable(GenericTable):
         exclude = ["desc", "view", "edit", "delete", "noduplicate"]
         sequence = ("subj", "obj", "...")
 
-    subj = tables.Column(verbose_name="Subject")
-    obj = tables.Column(verbose_name="Object")
+    subj = LinkedEntityColumn(verbose_name="Subject")
+    obj =  LinkedEntityColumn(verbose_name="Object")
 
     export_subj_pk = tables.Column(
         accessor="subj_object_id", verbose_name="subj_pk", visible=False
@@ -482,17 +510,10 @@ class TibScholRelationMixinTable(GenericTable):
         accessor="obj_object_id", verbose_name="obj_pk", visible=False
     )
 
-    def render_subj(self, value):
-        url = value.get_absolute_url()
-        return format_html('<a href="{}" target="_blank">{}</a>', url, value)
-
     def value_subj(self, value):
         return getattr(value, "name", "") or getattr(value, "label", "") or ""
 
-    def render_obj(self, value):
-        url = value.get_absolute_url()
-        return format_html('<a href="{}" target="_blank">{}</a>', url, value)
-
+ 
     def value_obj(self, value):
         return getattr(value, "name", "") or getattr(value, "label", "") or ""
 

--- a/apis_ontology/templates/apis_ontology/linked_entity_column.html
+++ b/apis_ontology/templates/apis_ontology/linked_entity_column.html
@@ -1,7 +1,12 @@
+{% load entity_display %}
 <div>
-    {% if entity_uri %}
-    <a href="{{entity_uri}}" target="_BLANK">{{entity_name}} ({{ entity_id }}) </a>
+    {% if entity %}
+        {% if entity.get_absolute_url %}
+            <a href="{{ entity.get_absolute_url }}" target="_BLANK">{% entity_display_name entity %} ({{ entity.pk }})</a>
+        {% else %}
+            {% entity_display_name entity %} ({{ entity.pk }})
+        {% endif %}
     {% else %}
-    {{entity_name}} ({{ entity_id }})
+        &mdash;
     {% endif %}
 </div>


### PR DESCRIPTION
This pull request refactors how linked entities (such as authors, subjects, and objects) are rendered in tables, improving code reuse and consistency. It introduces a new `LinkedEntityColumn` class, updates the `AuthorColumn` to use a template-based approach, and simplifies the rendering logic. The main template for linked entities is also improved for flexibility.

**Column and Rendering Refactoring:**

* Introduced a reusable `LinkedEntityColumn` class (subclassing `CustomTemplateColumn`) for rendering linked entities in tables, using the `apis_ontology/linked_entity_column.html` template. (`apis_ontology/tables.py`)
* Updated the `AuthorColumn` to inherit from `CustomTemplateColumn`, use the linked entity template, and refactored its `render` and `value` methods for consistency and code reuse. (`apis_ontology/tables.py`) [[1]](diffhunk://#diff-2ff430a2f96c033674f5795bd02c89280acef6d6b3e3d755ec2456e5e12b4b54L135-R146) [[2]](diffhunk://#diff-2ff430a2f96c033674f5795bd02c89280acef6d6b3e3d755ec2456e5e12b4b54L150-R178)
* Replaced direct HTML rendering in `render_subj` and `render_obj` with usage of `LinkedEntityColumn` for the `subj` and `obj` fields in tables. (`apis_ontology/tables.py`) [[1]](diffhunk://#diff-2ff430a2f96c033674f5795bd02c89280acef6d6b3e3d755ec2456e5e12b4b54L483-R504) [[2]](diffhunk://#diff-2ff430a2f96c033674f5795bd02c89280acef6d6b3e3d755ec2456e5e12b4b54L493-L502)

**Template Improvements:**

* Enhanced `apis_ontology/linked_entity_column.html` to use the `entity_display_name` template tag and to handle cases where an entity or its URL may be missing, improving robustness and display. (`apis_ontology/templates/apis_ontology/linked_entity_column.html`)

These changes make the codebase more maintainable and ensure a consistent display for linked entities across the application.