### PR TITLE
feat(filtersets): include search on Tibetan fields

### DIFF
--- a/apis_ontology/filtersets.py
+++ b/apis_ontology/filtersets.py
@@ -178,12 +178,13 @@ class PlaceFilterSet(TibScholEntityMixinFilterSet):
     # )
 
     def custom_name_search(self, queryset, name, value):
-        name_query = models.Q(label__unaccent__icontains=value) | models.Q(
-            alternative_names__unaccent__icontains=value
+        name_query = (
+            models.Q(label__unaccent__icontains=value)
+            | models.Q(alternative_names__unaccent__icontains=value)
+            | models.Q(tibetan_transliteration__icontains=value)
         )
         if value.isdigit():
             name_query = name_query | models.Q(pk=int(value))
-
         return queryset.filter(name_query)
 
 
@@ -205,12 +206,13 @@ class PersonFilterSet(TibScholEntityMixinFilterSet):
     # )
 
     def custom_name_search(self, queryset, name, value):
-        name_query = models.Q(name__unaccent__icontains=value) | models.Q(
-            alternative_names__unaccent__icontains=value
+        name_query = (
+            models.Q(name__unaccent__icontains=value)
+            | models.Q(alternative_names__unaccent__icontains=value)
+            | models.Q(tibetan_transliteration__icontains=value)
         )
         if value.isdigit():
             name_query = name_query | models.Q(pk=int(value))
-
         return queryset.filter(name_query)
 
 
@@ -232,12 +234,13 @@ class WorkFilterSet(TibScholEntityMixinFilterSet):
     # )
 
     def custom_name_search(self, queryset, name, value):
-        name_query = models.Q(name__unaccent__icontains=value) | models.Q(
-            alternative_names__unaccent__icontains=value
+        name_query = (
+            models.Q(name__unaccent__icontains=value)
+            | models.Q(alternative_names__unaccent__icontains=value)
+            | models.Q(tibetan_transliteration__icontains=value)
         )
         if value.isdigit():
             name_query = name_query | models.Q(pk=int(value))
-
         return queryset.filter(name_query)
 
 
@@ -265,10 +268,10 @@ class InstanceFilterSet(TibScholEntityMixinFilterSet):
             models.Q(name__unaccent__icontains=value)
             | models.Q(alternative_names__unaccent__icontains=value)
             | models.Q(tibschol_ref__icontains=value)
+            | models.Q(tibetan_transliteration__icontains=value)
         )
         if value.isdigit():
             name_query = name_query | models.Q(pk=int(value))
-
         return queryset.filter(name_query)
 
 


### PR DESCRIPTION
This pull request updates the custom name search functionality in several filter classes within `apis_ontology/filtersets.py` to improve how Tibetan transliterations are handled. The main enhancement is that searches will now also match the `tibetan_transliteration` field, making it easier to find entities using transliterated Tibetan names.

**Improvements to search functionality:**

* The `custom_name_search` method in multiple filter classes now includes the `tibetan_transliteration` field in its query, allowing users to search by transliterated Tibetan names. [[1]](diffhunk://#diff-5ac6e616e544d2b287f3183cf24bcad8eebf668eca1b421cbcad54870356ed59L181-L186) [[2]](diffhunk://#diff-5ac6e616e544d2b287f3183cf24bcad8eebf668eca1b421cbcad54870356ed59L208-L213) [[3]](diffhunk://#diff-5ac6e616e544d2b287f3183cf24bcad8eebf668eca1b421cbcad54870356ed59L235-L240) [[4]](diffhunk://#diff-5ac6e616e544d2b287f3183cf24bcad8eebf668eca1b421cbcad54870356ed59R271-L271)