### PR TITLE
Core chore

### DIFF
--- a/apis_ontology/static/styles/tibschol.css
+++ b/apis_ontology/static/styles/tibschol.css
@@ -79,3 +79,6 @@ pre#rawTEI{
     direction: ltr;
 }
 
+td:has(.actions-column) {
+  width: auto !important;
+}

--- a/apis_ontology/tables.py
+++ b/apis_ontology/tables.py
@@ -38,7 +38,7 @@ def preview_text(text, n=50):
 
 class TibscholEntityMixinTable(GenericTable):
     class Meta(GenericTable.Meta):
-        exclude = ["id", "desc", "view", "edit", "delete", "noduplicate"]
+        exclude = ["id", "desc", "actions"]
         sequence = (
             "name",
             "...",
@@ -79,7 +79,7 @@ class TibscholEntityMixinTable(GenericTable):
     )
 
     def render_name(self, record):
-        return display_entity_name(record, getattr(self, 'request', None))
+        return display_entity_name(record, getattr(self, "request", None))
 
     def value_name(self, record):
         return getattr(record, "label", getattr(record, "name", ""))
@@ -134,11 +134,12 @@ class PersonDateColumn(tables.Column):
 
 class AuthorColumn(CustomTemplateColumn):
     template_name = "apis_ontology/linked_entity_column.html"
+
     def __init__(self, *args, **kwargs):
         self.orderable = kwargs.get("orderable", False)
         self.verbose_name = kwargs.get("verbose_name", None)
         kwargs.pop("orderable", None)
-        kwargs.pop("verbose_name", None)    
+        kwargs.pop("verbose_name", None)
         super().__init__(
             *args,
             **kwargs,
@@ -158,7 +159,7 @@ class AuthorColumn(CustomTemplateColumn):
                     work_instance_id,
                 )
 
-    def render(self, record,table, value, *args, **kwargs):
+    def render(self, record, table, value, *args, **kwargs):
         subj_work = self.__class__.get_work_from_id(value)
         if not subj_work:
             return ""
@@ -175,7 +176,7 @@ class AuthorColumn(CustomTemplateColumn):
 
         return ""
 
-    def value(self,record, table, value, *args, **kwargs):
+    def value(self, record, table, value, *args, **kwargs):
         work = self.get_work_from_id(value)
         if not work:
             return ""
@@ -224,7 +225,6 @@ class PersonTable(TibscholEntityMixinTable):
     class Meta(TibscholEntityMixinTable.Meta):
         model = Person
         fields = ["name"]
-        # exclude = ["id", "desc", "view", "edit", "noduplicate", "delete"]
 
     export_lifedate_start = tables.Column(
         accessor="start", verbose_name="Life date start", visible=False
@@ -358,16 +358,14 @@ class TibScholEntityMixinRelationsTable(GenericTable):
     )
 
     class Meta(GenericTable.Meta):
-        exclude = ["desc", "noduplicate"]
+        exclude = ["desc"]
         per_page = 1000
         sequence = (
             "relation",
             "predicate",
             "...",
             "references",
-            "view",
-            "edit",
-            "delete",
+            "actions",
         )
 
 
@@ -468,6 +466,7 @@ class TibScholEntityMixinPersonRelationsTable(TibScholEntityMixinRelationsTable)
     class Meta(TibScholEntityMixinRelationsTable.Meta):
         pass
 
+
 class LinkedEntityColumn(CustomTemplateColumn):
     template_name = "apis_ontology/linked_entity_column.html"
     orderable = True
@@ -477,18 +476,18 @@ class LinkedEntityColumn(CustomTemplateColumn):
             self.verbose_name = kwargs.pop("verbose_name")
         if "orderable" in kwargs:
             self.orderable = kwargs.pop("orderable")
-        
+
         super().__init__(*args, **kwargs)
 
     def render(self, record, *args, **kwargs):
         self.extra_context = {
             "entity": getattr(record, str(self.accessor), None),
         }
-        return super().render(record,*args,**kwargs)
+        return super().render(record, *args, **kwargs)
+
+        return super().render(record, table, value, bound_column, **kwargs)
 
 
-        return super().render(record, table, value, bound_column, **kwargs) 
-    
 class TibScholRelationMixinTable(GenericTable):
     paginate_by = 100
     export_filename = (
@@ -497,11 +496,11 @@ class TibScholRelationMixinTable(GenericTable):
 
     class Meta(GenericTable.Meta):
         fields = ["subj", "obj"]
-        exclude = ["desc", "view", "edit", "delete", "noduplicate"]
+        exclude = ["desc", "actions"]
         sequence = ("subj", "obj", "...")
 
     subj = LinkedEntityColumn(verbose_name="Subject")
-    obj =  LinkedEntityColumn(verbose_name="Object")
+    obj = LinkedEntityColumn(verbose_name="Object")
 
     export_subj_pk = tables.Column(
         accessor="subj_object_id", verbose_name="subj_pk", visible=False
@@ -513,7 +512,6 @@ class TibScholRelationMixinTable(GenericTable):
     def value_subj(self, value):
         return getattr(value, "name", "") or getattr(value, "label", "") or ""
 
- 
     def value_obj(self, value):
         return getattr(value, "name", "") or getattr(value, "label", "") or ""
 
@@ -979,9 +977,9 @@ class PersonAuthorOfWorkTable(TibScholRelationMixinTable):
 
 class ExcerptsTable(GenericTable):
     class Meta(GenericTable.Meta):
-        exclude = ["desc", "edit"]
+        exclude = ["desc", "actions"]
         fields = ["xml_id", "xml_content"]
-        sequence = ["xml_id", "xml_content", "...", "view", "delete"]
+        sequence = ["xml_id", "xml_content", "..."]
         per_page = 100
 
     def render_xml_id(self, value):
@@ -993,7 +991,7 @@ class ExcerptsTable(GenericTable):
 
 class ZoteroEntryTable(GenericTable):
     class Meta(GenericTable.Meta):
-        exclude = ["desc", "view", "edit", "delete"]
+        exclude = ["desc", "actions"]
         fields = ["zoteroId", "shortTitle", "fullCitation", "year"]
         sequence = fields + ["..."]
         per_page = 100
@@ -1012,10 +1010,10 @@ class SubjectTable(GenericTable):
         exclude = [
             "id",
             "desc",
-            "view",
+            "actions",
         ]
         fields = ["name"]
-        sequence = ("name", "...", "edit", "delete")
+        sequence = ("name", "...")
 
     works = tables.Column(orderable=False, verbose_name="Works", accessor="pk")
 

--- a/apis_ontology/templates/columns/actions.html
+++ b/apis_ontology/templates/columns/actions.html
@@ -1,0 +1,17 @@
+{% load i18n %}
+<div class="actions-column">
+    {% if record.get_view_permission in perms %}
+    <a title="{% translate " view" %}" href="{{ record.get_absolute_url }}" class="object-view"><span
+            class="material-symbols-outlined">visibility</span></a>
+    {% endif %}
+    {% if record.get_change_permission in perms %}
+    <a title="{% translate " edit" %}" href="{{ record.get_edit_url }}" class="object-edit"><span
+            class="material-symbols-outlined">edit</span></a>
+    {% endif %}
+    {% if record.get_delete_permission in perms %}
+    <a title="{% translate " delete" %}" hx-delete="{{ record.get_api_detail_endpoint }}"
+        hx-confirm="{% blocktranslate %}Are your sure you want to delete {{ record }}?{% endblocktranslate %}"
+        hx-target="closest tr" hx-swap="outerHTML swap:0.3s" href="{{ record.get_delete_url }}"
+        class="object-delete"><span class="material-symbols-outlined">delete</span></a>
+    {% endif %}
+</div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 requires-python = ">=3.13"
 dependencies = [
     "psycopg2==2.9.*",
-    "apis-core-rdf==0.59.0",
+    "apis-core-rdf==0.62.0",
     "apis-acdhch-default-settings==2.18.0",
     "django-extensions==4.1.*",
     "tqdm==4.67.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires-python = ">=3.13"
 dependencies = [
     "psycopg2==2.9.*",
     "apis-core-rdf==0.59.0",
-    "apis-acdhch-default-settings==2.16.0",
+    "apis-acdhch-default-settings==2.18.0",
     "django-extensions==4.1.*",
     "tqdm==4.67.3",
     "pandas==3.0.1",


### PR DESCRIPTION
This pull request refactors how action links (view, edit, delete) are handled in table views by consolidating them into a single `actions` column rendered via a new template. It updates table configurations to use this new approach, removes individual action columns, and ensures consistent styling and permission checks. Additionally, dependency versions are updated.

**Table action columns refactor:**

* Added a new `actions.html` template to render view, edit, and delete links with permission checks, consolidating action links into a single column (`apis_ontology/templates/columns/actions.html`).
* Updated all table `Meta` classes in `apis_ontology/tables.py` to exclude individual action columns (like `view`, `edit`, `delete`, `noduplicate`) and instead include the new `actions` column, simplifying configuration and improving maintainability. [[1]](diffhunk://#diff-2ff430a2f96c033674f5795bd02c89280acef6d6b3e3d755ec2456e5e12b4b54L41-R41) [[2]](diffhunk://#diff-2ff430a2f96c033674f5795bd02c89280acef6d6b3e3d755ec2456e5e12b4b54L361-R368) [[3]](diffhunk://#diff-2ff430a2f96c033674f5795bd02c89280acef6d6b3e3d755ec2456e5e12b4b54L500-R499) [[4]](diffhunk://#diff-2ff430a2f96c033674f5795bd02c89280acef6d6b3e3d755ec2456e5e12b4b54L982-R982) [[5]](diffhunk://#diff-2ff430a2f96c033674f5795bd02c89280acef6d6b3e3d755ec2456e5e12b4b54L996-R994) [[6]](diffhunk://#diff-2ff430a2f96c033674f5795bd02c89280acef6d6b3e3d755ec2456e5e12b4b54L1015-R1016)

**Styling improvements:**

* Added CSS to ensure the new `.actions-column` adapts its width appropriately, improving table layout (`apis_ontology/static/styles/tibschol.css`).

**Dependency updates:**

* Bumped `apis-core-rdf` to 0.62.0 and `apis-acdhch-default-settings` to 2.18.0 in `pyproject.toml` for up-to-date features and fixes.

**Minor code cleanup:**

* Fixed minor formatting and removed commented code for consistency in `apis_ontology/tables.py`. [[1]](diffhunk://#diff-2ff430a2f96c033674f5795bd02c89280acef6d6b3e3d755ec2456e5e12b4b54L227) [[2]](diffhunk://#diff-2ff430a2f96c033674f5795bd02c89280acef6d6b3e3d755ec2456e5e12b4b54R137) [[3]](diffhunk://#diff-2ff430a2f96c033674f5795bd02c89280acef6d6b3e3d755ec2456e5e12b4b54R469) [[4]](diffhunk://#diff-2ff430a2f96c033674f5795bd02c89280acef6d6b3e3d755ec2456e5e12b4b54L516) [[5]](diffhunk://#diff-2ff430a2f96c033674f5795bd02c89280acef6d6b3e3d755ec2456e5e12b4b54L489-R490) [[6]](diffhunk://#diff-2ff430a2f96c033674f5795bd02c89280acef6d6b3e3d755ec2456e5e12b4b54L82-R82)