### PR TITLE
fix: update transliterations

### DIFF
--- a/apis_ontology/signals.py
+++ b/apis_ontology/signals.py
@@ -1,75 +1,80 @@
-from django.db.models.signals import post_save
-from apis_ontology.models import Person, Place, Work, Instance
+from django.db.models.signals import pre_save, post_save
+
+from apis_ontology.models import Instance, Person, Place, Work
 from apis_ontology.utils import latin_to_tibetan
+
 
 # Helper to determine if transliteration should be updated
 def get_tibetan_transliteration(obj):
     # Work: only if original_language == 'Tibetan'
-    if hasattr(obj, 'original_language'):
-        if getattr(obj, 'original_language', None) == 'Tibetan' and getattr(obj, 'name', None):
+    if hasattr(obj, "original_language"):
+        if getattr(obj, "original_language", None) == "Tibetan" and getattr(
+            obj, "name", None
+        ):
             return latin_to_tibetan(obj.name)
-        return ''
+        return ""
     # Instance: only if it is an instance of a work whose language is Tibetan
-    if obj.__class__.__name__ == 'Instance':
-        from apis_ontology.models import WorkHasAsAnInstanceInstance, Work
+    if obj.__class__.__name__ == "Instance":
+        from apis_ontology.models import Work, WorkHasAsAnInstanceInstance
+
         rel = WorkHasAsAnInstanceInstance.objects.filter(obj_object_id=obj.pk).first()
         work = Work.objects.filter(pk=rel.subj_object_id).first() if rel else None
-        if work and work.original_language == 'Tibetan' and getattr(obj, 'name', None):
+        if work and work.original_language == "Tibetan" and getattr(obj, "name", None):
             return latin_to_tibetan(obj.name)
-        return ''
+        return ""
     # Person: only if nationality == 'Tibetan'
-    if hasattr(obj, 'nationality'):
-        if getattr(obj, 'nationality', None) == 'Tibetan' and getattr(obj, 'name', None):
+    if hasattr(obj, "nationality"):
+        if getattr(obj, "nationality", None) == "Tibetan" and getattr(
+            obj, "name", None
+        ):
             return latin_to_tibetan(obj.name)
-        return ''
+        return ""
     # Place: always transliterate label
-    if hasattr(obj, 'label') and getattr(obj, 'label', None):
+    if hasattr(obj, "label") and getattr(obj, "label", None):
         return latin_to_tibetan(obj.label)
-    return ''
+    return ""
 
-
-from django.db import transaction
 
 def update_transliteration(sender, instance, **kwargs):
-    # If the instance was just created, always set transliteration
-    if kwargs.get('created', False):
+    # If called from post_save (creation), only run if created=True
+    if kwargs.get("created", False):
         new_translit = get_tibetan_transliteration(instance)
         if instance.tibetan_transliteration != new_translit:
             instance.tibetan_transliteration = new_translit
-            instance.save(update_fields=['tibetan_transliteration'])
+            instance.save(update_fields=["tibetan_transliteration"])
         return
 
-    # For updates, only auto-update if the field was not changed by the user
-    # This requires checking the previous value in the DB
-    model = type(instance)
-    try:
-        old = model.objects.get(pk=instance.pk)
-    except model.DoesNotExist:
-        old = None
+    # If called from pre_save (update), only run if instance.pk exists (i.e., not creation)
+    if instance.pk:
+        model = type(instance)
+        try:
+            old = model.objects.get(pk=instance.pk)
+        except model.DoesNotExist:
+            old = None
+
+        # If the transliteration field was changed by the user, always persist it as-is (do nothing)
+        if old and old.tibetan_transliteration != instance.tibetan_transliteration:
+            return
+
+        # Otherwise, update if needed
+        new_translit = get_tibetan_transliteration(instance)
+        if instance.tibetan_transliteration != new_translit:
+            instance.tibetan_transliteration = new_translit
+            # No need to save here; pre_save will persist the change
 
 
-    # If the transliteration field was changed by the user, always persist it as-is (do nothing)
-    if old and old.tibetan_transliteration != instance.tibetan_transliteration:
-        # User changed the field, so just persist their value and do not auto-update
-        return
-
-    # Otherwise, update if needed
-    new_translit = get_tibetan_transliteration(instance)
-    if instance.tibetan_transliteration != new_translit:
-        # Use transaction.on_commit to avoid recursion
-        def do_update():
-            model.objects.filter(pk=instance.pk).update(tibetan_transliteration=new_translit)
-        transaction.on_commit(do_update)
-
+# Connect update_transliteration to both pre_save and post_save for all relevant models
 for model in [Person, Place, Work, Instance]:
+    pre_save.connect(update_transliteration, sender=model)
     post_save.connect(update_transliteration, sender=model)
 import os
-from django.contrib.auth.signals import user_logged_in
-from django.dispatch import receiver
-from django.contrib.auth.models import Group
-from django.db.models.signals import pre_delete
+
 from apis_core.apis_entities.models import RootObject
 from apis_core.relations.models import Relation
+from django.contrib.auth.models import Group
+from django.contrib.auth.signals import user_logged_in
+from django.db.models.signals import pre_delete
+from django.dispatch import receiver
 
 
 @receiver(user_logged_in)


### PR DESCRIPTION
This pull request refactors and improves the Tibetan transliteration update logic in `apis_ontology/signals.py`. The main changes include connecting the transliteration update to both `pre_save` and `post_save` signals, improving the logic for when and how transliteration is updated, and cleaning up the code for clarity.

**Signal connection and update logic improvements:**

* Connected the `update_transliteration` function to both `pre_save` and `post_save` signals for `Person`, `Place`, `Work`, and `Instance` models, ensuring transliteration is updated both on creation and update.
* Refactored `update_transliteration` to distinguish between creation (handled in `post_save`) and updates (handled in `pre_save`), updating the transliteration only when necessary and avoiding unnecessary database saves.

**Code cleanup and consistency:**

* Standardized string quoting (using double quotes), improved line breaks for readability, and reordered imports for clarity and consistency.
* Removed unnecessary use of `transaction.on_commit` and simplified the update logic to avoid recursion and redundant saves.

These changes make the transliteration update mechanism more robust and maintainable.