### PR TITLE
feat: alt labels field

### DIFF
--- a/apis_ontology/fields.py
+++ b/apis_ontology/fields.py
@@ -1,0 +1,86 @@
+# fields.py
+
+from django.db import models
+from django import forms
+from django.utils.safestring import mark_safe
+from django.utils.html import escape
+from django.template.loader import render_to_string
+import json
+
+
+class AlternativeLabelsWidget(forms.Widget):
+    def format_value(self, value):
+        if value is None:
+            return '[]'
+        if isinstance(value, str):
+            try:
+                # ensure it's valid JSON
+                json.loads(value)
+                return value
+            except Exception:
+                return json.dumps([])
+        try:
+            return json.dumps(value)
+        except Exception:
+            return json.dumps([])
+
+    def render(self, name, value, attrs=None, renderer=None):
+        val = self.format_value(value)
+        # parse into list of {'language':..,'label':..}
+        parsed = []
+        try:
+            parsed = json.loads(val)
+            if isinstance(parsed, dict):
+                parsed = [{'language': k, 'label': v} for k, v in parsed.items()]
+        except Exception:
+            parsed = []
+
+        context = {
+            'name': name,
+            'value': val,
+            'items': parsed,
+        }
+        html = render_to_string('apis_ontology/altlabels_widget.html', context)
+        return mark_safe(html)
+
+    def value_from_datadict(self, data, files, name):
+        # widget stores JSON string in hidden input with the field name
+        return data.get(name, '[]')
+
+
+class AlternativeLabelsWidgetFormField(forms.JSONField):
+    widget = AlternativeLabelsWidget
+
+
+class AlternativeLabelsField(models.JSONField):
+    def formfield(self, **kwargs):
+        defaults = {
+            "form_class": AlternativeLabelsWidgetFormField,
+        }
+        defaults.update(kwargs)
+        return super().formfield(**defaults)
+
+    def value_to_string(self, obj):
+        value = self.value_from_object(obj)
+        return self._stringify(value)
+
+    def _stringify(self, value):
+        # value can be None, a dict, or a list of dicts
+        import json
+        if not value:
+            return ""
+        try:
+            if isinstance(value, str):
+                value = json.loads(value)
+        except Exception:
+            return str(value)
+        if isinstance(value, dict):
+            items = [f"{v} ({k})" for k, v in value.items()]
+        elif isinstance(value, list):
+            items = [
+                f"{item.get('label','')} ({item.get('language','')})".strip()
+                for item in value if item.get('label') or item.get('language')
+            ]
+        else:
+            return str(value)
+        return ", ".join(items)

--- a/apis_ontology/migrations/0077_rename_alternative_names_add_altlabels_field.py
+++ b/apis_ontology/migrations/0077_rename_alternative_names_add_altlabels_field.py
@@ -1,0 +1,46 @@
+# Rewritten to handle PostgreSQL type casting issue when converting TextField -> JSONField
+
+import apis_ontology.fields
+from django.db import migrations, models
+
+MODELS = ["instance", "person", "place", "versioninstance", "versionperson", "versionplace", "versionwork", "work"]
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("apis_ontology", "0076_alter_instance_tibetan_transliteration_and_more"),
+    ]
+
+    operations = (
+        # Step 1: add legacy TextField columns
+        [
+            migrations.AddField(
+                model_name=model,
+                name="alternative_names_legacy",
+                field=models.TextField(
+                    blank=True, null=True, verbose_name="Alternative names (legacy)"
+                ),
+            )
+            for model in MODELS
+        ]
+        # Step 2: copy existing text data into legacy columns, then NULL out the original
+        + [
+            migrations.RunSQL(
+                sql=f"UPDATE apis_ontology_{model} SET alternative_names_legacy = alternative_names; "
+                    f"UPDATE apis_ontology_{model} SET alternative_names = NULL;",
+                reverse_sql=f"UPDATE apis_ontology_{model} SET alternative_names = alternative_names_legacy;",
+            )
+            for model in MODELS
+        ]
+        # Step 3: alter the now-empty alternative_names column to JSONField
+        + [
+            migrations.AlterField(
+                model_name=model,
+                name="alternative_names",
+                field=apis_ontology.fields.AlternativeLabelsField(
+                    blank=True, null=True, verbose_name="Alternative names"
+                ),
+            )
+            for model in MODELS
+        ]
+    )

--- a/apis_ontology/migrations/0078_copy_alternative_names_to_altlabels.py
+++ b/apis_ontology/migrations/0078_copy_alternative_names_to_altlabels.py
@@ -1,0 +1,23 @@
+from django.db import migrations
+
+
+def copy_alternative_names(apps, schema_editor):
+    models_to_migrate = ["Person", "Place", "Work", "Instance"]
+    for model_name in models_to_migrate:
+        Model = apps.get_model("apis_ontology", model_name)
+        for obj in Model.objects.exclude(alternative_names_legacy__isnull=True).exclude(alternative_names_legacy=""):
+            raw = obj.alternative_names_legacy or ""
+            items = [line.strip() for line in raw.splitlines() if line.strip()]
+            obj.alternative_names = [{"label": item, "language": "bo"} for item in items]
+            obj.save(update_fields=["alternative_names"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("apis_ontology", "0077_rename_alternative_names_add_altlabels_field"),
+    ]
+
+    operations = [
+        migrations.RunPython(copy_alternative_names, migrations.RunPython.noop),
+    ]

--- a/apis_ontology/models.py
+++ b/apis_ontology/models.py
@@ -22,6 +22,7 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from django_interval.fields import FuzzyDateParserField
 from .date_utils import tibschol_dateparser
+from .fields import AlternativeLabelsField
 from auditlog.registry import auditlog
 
 logger = logging.getLogger(__name__)
@@ -52,7 +53,10 @@ class TibScholEntityMixin(models.Model):
         abstract = True
     tibetan_transliteration = models.CharField(max_length=255, blank=True, default="", verbose_name=_("Tibetan script"))
     comments = models.TextField(blank=True, null=True)
-    alternative_names = models.TextField(
+    alternative_names_legacy = models.TextField(
+        blank=True, null=True, verbose_name=_("Alternative names (legacy)")
+    )
+    alternative_names = AlternativeLabelsField(
         blank=True, null=True, verbose_name=_("Alternative names")
     )
     external_links = models.TextField(

--- a/apis_ontology/templates/apis_ontology/altlabels_widget.html
+++ b/apis_ontology/templates/apis_ontology/altlabels_widget.html
@@ -1,0 +1,101 @@
+
+<div class="altlabels-widget" data-name="{{ name }}">
+  <input type="hidden" name="{{ name }}" id="id_{{ name }}" value='{{ value|escapejs }}'>
+
+  <div class="altlabels-editor row g-2 align-items-center mb-2">
+    <div class="col-auto" style="flex-basis: 100px; min-width: 80px; max-width: 150px;">
+      <input class="altlabels-lang form-control form-control-sm" placeholder="Language" aria-label="language" style="width: 100%;">
+    </div>
+    <div class="col" style="min-width: 150px;">
+      <input class="altlabels-label form-control form-control-sm" placeholder="Label" aria-label="label" style="width: 100%;">
+    </div>
+    <div class="col-auto">
+      <button type="button" class="altlabels-add btn btn-primary btn-sm">+</button>
+    </div>
+  </div>
+
+  <div class="altlabels-list" aria-live="polite">
+    {# Items will be rendered by JS from the hidden value as editable rows #}
+  </div>
+</div>
+
+<script>
+(function(){
+  var container = document.querySelector('.altlabels-widget[data-name="{{ name }}"]');
+  if(!container) return;
+  var hidden = container.querySelector('input[type=hidden]');
+  var editorLang = container.querySelector('.altlabels-lang');
+  var editorLabel = container.querySelector('.altlabels-label');
+  var addBtn = container.querySelector('.altlabels-add');
+  var listDiv = container.querySelector('.altlabels-list');
+
+
+  function getItems(){
+    try {
+        var raw = hidden.value || '[]';
+        // Unescape \u0022 to ", if present
+        var val = JSON.parse(raw.replace(/\\u0022/g, '"'));
+      if (!Array.isArray(val)) return [];
+      return val;
+    } catch(e) { return []; }
+  }
+
+  function setItems(items){
+    hidden.value = JSON.stringify(items);
+  }
+
+  function render(){
+    listDiv.innerHTML = '';
+    var items = getItems();
+    items.forEach(function(it, idx){
+      var row = document.createElement('div');
+      row.className = 'altlabels-row row g-2 align-items-center mb-1';
+      row.innerHTML =
+        '<div class="col-auto" style="flex-basis: 100px; min-width: 80px; max-width: 150px;">'
+        + '<input class="altlabels-lang-edit form-control form-control-sm" placeholder="Language" value="'+(it.language||'')+'" style="width: 100%;">'
+        + '</div>'
+        + '<div class="col" style="min-width: 150px;">'
+        + '<input class="altlabels-label-edit form-control form-control-sm" placeholder="Label" value="'+(it.label||'')+'" style="width: 100%;">'
+        + '</div>'
+        + '<div class="col-auto">'
+        + '<button type="button" class="altlabels-remove btn btn-danger btn-sm">X</button>'
+        + '</div>';
+
+      // Update on input
+      row.querySelector('.altlabels-lang-edit').addEventListener('input', function(e){
+        items[idx].language = e.target.value;
+        setItems(items);
+      });
+      row.querySelector('.altlabels-label-edit').addEventListener('input', function(e){
+        items[idx].label = e.target.value;
+        setItems(items);
+      });
+      row.querySelector('.altlabels-remove').addEventListener('click', function(){
+        items.splice(idx,1);
+        setItems(items);
+        render();
+      });
+      listDiv.appendChild(row);
+    });
+  }
+
+
+  addBtn.addEventListener('click', function(){
+    var lang = editorLang.value.trim();
+    var label = editorLabel.value.trim();
+    if(!lang && !label) return;
+    var items = getItems();
+    if (!Array.isArray(items)) items = [];
+    items.push({language: lang, label: label});
+    setItems(items);
+    editorLang.value = '';
+    editorLabel.value = '';
+    render();
+  });
+
+  var form = hidden.closest('form');
+  if(form) form.addEventListener('submit', function(){ setItems(getItems()); });
+
+  render();
+})();
+</script>

--- a/apis_ontology/templates/apis_ontology/partials/instance_card_table.html
+++ b/apis_ontology/templates/apis_ontology/partials/instance_card_table.html
@@ -16,10 +16,20 @@
         </td>
     </tr>
     {% if object.alternative_names %}
-    <tr>
-        <th>Alternative names</th>
-        <td>{{ object.alternative_names | render_list_field }}</td>
-    </tr>
+        <tr>
+            <th>Alternative names</th>
+            <td>
+            <ul class="list-unstyled mb-0">
+            {% for item in object.alternative_names %}
+            {% if item.label or item.language %}
+            <li>
+            {{ item.label }}{% if item.language %} ({{ item.language }}){% endif %}
+            </li>
+            {% endif %}
+            {% endfor %}
+            </ul>
+            </td>
+        </tr>
     {% endif %}
 
     {% if object.start %}

--- a/apis_ontology/templates/apis_ontology/partials/person_card_table.html
+++ b/apis_ontology/templates/apis_ontology/partials/person_card_table.html
@@ -1,6 +1,7 @@
 {% load generic %}
 {% load filter_utils %}
 {% load parse_comment %}
+{% modeldict object as d %}
 
 <table class="table table-hover">
     <tr>
@@ -17,12 +18,18 @@
     </tr>
     {% if object.alternative_names %}
         <tr>
-        <th>
-            Alternative names
-        </th>
-        <td>
-            {{ object.alternative_names | render_list_field }}
-        </td>
+            <th>Alternative names</th>
+            <td>
+            <ul class="list-unstyled mb-0">
+                {% for item in object.alternative_names %}
+                {% if item.label or item.language %}
+                    <li>
+                    {{ item.label }}{% if item.language %} ({{ item.language }}){% endif %}
+                    </li>
+                {% endif %}
+                {% endfor %}
+            </ul>
+           </td>
         </tr>
     {% endif %}
 

--- a/apis_ontology/templates/apis_ontology/partials/place_card_table.html
+++ b/apis_ontology/templates/apis_ontology/partials/place_card_table.html
@@ -18,11 +18,17 @@
     </tr>
     {% if object.alternative_names %}
         <tr>
-            <th>
-                Alternative names
-            </th>
+            <th>Alternative names</th>
             <td>
-                {{ object.alternative_names | render_list_field }}
+            <ul class="list-unstyled mb-0">
+                {% for item in object.alternative_names %}
+                {% if item.label or item.language %}
+                    <li>
+                    {{ item.label }}{% if item.language %} ({{ item.language }}){% endif %}
+                    </li>
+                {% endif %}
+                {% endfor %}
+            </ul>
             </td>
         </tr>
     {% endif %}

--- a/apis_ontology/templates/apis_ontology/partials/work_card_table.html
+++ b/apis_ontology/templates/apis_ontology/partials/work_card_table.html
@@ -17,7 +17,17 @@
     {% if object.alternative_names %}
         <tr>
             <th>Alternative names</th>
-            <td>{{ object.alternative_names | render_list_field }}</td>
+            <td>
+            <ul class="list-unstyled mb-0">
+                {% for item in object.alternative_names %}
+                {% if item.label or item.language %}
+                    <li>
+                    {{ item.label }}{% if item.language %} ({{ item.language }}){% endif %}
+                    </li>
+                {% endif %}
+                {% endfor %}
+            </ul>
+            </td>
         </tr>
     {% endif %}
     {% if object.original_language %}


### PR DESCRIPTION
This pull request migrates the `alternative_names` field in several ontology models from a plain text field to a structured JSON field with a custom form widget, improving data consistency and user experience for editing multilingual labels. It also updates migrations, templates, and the model to support this new format, and ensures legacy data is preserved and migrated.

**Migration and Data Model Changes:**

* Introduced a new custom `AlternativeLabelsField` (a subclass of `models.JSONField`) and associated form/widget (`AlternativeLabelsWidget`) for the `alternative_names` field in relevant models, replacing the previous `TextField` implementation. This allows storing and editing alternative names as structured objects with language and label attributes. [[1]](diffhunk://#diff-6a2cd2191f99d2b5011e45a321795702a4a76dfc0a19d48ef7cca68faa6786b3R1-R86) [[2]](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1L55-R59)
* Added a migration (`0077_rename_alternative_names_add_altlabels_field.py`) that safely transitions the `alternative_names` field from `TextField` to `AlternativeLabelsField`, including creating a legacy column to preserve existing data and handling PostgreSQL type casting.
* Added a follow-up migration (`0078_copy_alternative_names_to_altlabels.py`) to convert and copy legacy text data into the new JSON structure, defaulting language to `"bo"`.

**Frontend and Template Enhancements:**

* Implemented a custom form widget (`altlabels_widget.html` and associated JS) for editing alternative names as a list of language/label pairs, improving usability in the Django admin or other forms.
* Updated display templates for `Person`, `Place`, `Work`, and `Instance` to render the new structured alternative names, showing each label with its language in a user-friendly list. [[1]](diffhunk://#diff-6c8e68afacefedf8610a0f11547e5e92689088e72495381aee6eae5cb6c5bdbbL20-R31) [[2]](diffhunk://#diff-715ce28d1b70c110478099985334e75f9b65aaf19c05e74122e9b645ebe73ce1L21-R32) [[3]](diffhunk://#diff-7534da6c5a714a1d687515bbe2d9719e7731e4136bd60e8358d32f8bea29e752L21-R32) [[4]](diffhunk://#diff-e870c7464d5564c0163460d91fcfa9ae1861834176df7133db6c17e4bbc866bfL20-R31)

**Other Improvements:**

* Updated model imports and template context usage to support the new field and its rendering. [[1]](diffhunk://#diff-118e3de32da4d445c8a945680c3cedd2771413121632a587821a7b4a716614f1R25) [[2]](diffhunk://#diff-6c8e68afacefedf8610a0f11547e5e92689088e72495381aee6eae5cb6c5bdbbR4)

These changes collectively modernize how alternative names are stored and edited, supporting future extensibility and multilingual data integrity.