### PR TITLE
feat: remove language code while displaying alternate names

### DIFF
--- a/apis_ontology/templates/apis_ontology/partials/instance_card_table.html
+++ b/apis_ontology/templates/apis_ontology/partials/instance_card_table.html
@@ -23,7 +23,7 @@
             {% for item in object.alternative_names %}
             {% if item.label or item.language %}
             <li>
-            {{ item.label }}{% if item.language %} ({{ item.language }}){% endif %}
+            {{ item.label }}{% if item.language %}{% endif %}
             </li>
             {% endif %}
             {% endfor %}

--- a/apis_ontology/templates/apis_ontology/partials/person_card_table.html
+++ b/apis_ontology/templates/apis_ontology/partials/person_card_table.html
@@ -24,7 +24,7 @@
                 {% for item in object.alternative_names %}
                 {% if item.label or item.language %}
                     <li>
-                    {{ item.label }}{% if item.language %} ({{ item.language }}){% endif %}
+                    {{ item.label }}{% if item.language %}{% endif %}
                     </li>
                 {% endif %}
                 {% endfor %}

--- a/apis_ontology/templates/apis_ontology/partials/place_card_table.html
+++ b/apis_ontology/templates/apis_ontology/partials/place_card_table.html
@@ -24,7 +24,7 @@
                 {% for item in object.alternative_names %}
                 {% if item.label or item.language %}
                     <li>
-                    {{ item.label }}{% if item.language %} ({{ item.language }}){% endif %}
+                    {{ item.label }}{% if item.language %}{% endif %}
                     </li>
                 {% endif %}
                 {% endfor %}

--- a/apis_ontology/templates/apis_ontology/partials/work_card_table.html
+++ b/apis_ontology/templates/apis_ontology/partials/work_card_table.html
@@ -22,7 +22,7 @@
                 {% for item in object.alternative_names %}
                 {% if item.label or item.language %}
                     <li>
-                    {{ item.label }}{% if item.language %} ({{ item.language }}){% endif %}
+                    {{ item.label }}{% if item.language %}{% endif %}
                     </li>
                 {% endif %}
                 {% endfor %}


### PR DESCRIPTION
This pull request makes a small but consistent change across several template partials. The change removes the display of the alternative name's language (previously shown in parentheses) from the alternative names lists for different object types.

Template updates for alternative names:

* Removed the display of the language (e.g., "(en)") next to each alternative name label in the following partials:
  * `instance_card_table.html`
  * `person_card_table.html`
  * `place_card_table.html`
  * `work_card_table.html`