### PR TITLE
feat(imprint): update imprint page

### DIFF
--- a/apis_ontology/templates/imprint.html
+++ b/apis_ontology/templates/imprint.html
@@ -7,26 +7,16 @@
                 <p>The dataset contained in the database is placed under the Creative Commons license CC0, at the exception of Comments (in
                 pages related to Person, Work, Instance, Place) and Item description (in Instance pages), which are placed under the
                     <a target="_blank" href="https://creativecommons.org/licenses/by/4.0/">Creative Common license CC BY 4.0</a>.</p>
-
-                <p>Dates for Persons are, unless they are approximated (before/after) or it is indicated otherwise in the Comments, those
-                    provided by <a target="_blank" href="https://library.bdrc.io/">the Buddhist Digital Resource Center</a> under CC0 license at the URL indicated under “External links.”</p>
-
-                <p>For Indic Works and their author, we used the title and name provided by the <a target="_blank" href="http://www.rkts.org/">rKTs project</a>. More
-                    details can be obtained on these works by following the external link to rKTs.</p>
-
-                <p>Coordinates for Places are, unless indicated otherwise in the Comments, those provided by the Buddhist Digital Resource
-                    Center under CC0 license at the URL indicated under “External links.”</p>
-
-                <p>Please note and respect the copyright regulations specific to other resources referred to in the database, such as
+                    <p>Text excerpts (<span class="material-symbols-outlined">text_snippet</span>) are from works in the Public Domain.
+                        Related TEI files that contain these excerpts, hosted at <a target="_blank"
+                            href="https://github.com/ERC-TibSchol/TibSchol-TEI-Library">TibSchol-TEI-Library</a>,
+                        are distributed under a <a target="_blank" href="https://creativecommons.org/licenses/by-sa/4.0/">Creative Common CC
+                            BY-SA 4.0
+                            License</a>. </p>
+                    <p>To cite information provided in Comments and Item description, use the URL and access date.</p>
+                    <p>Please note and respect the copyright regulations specific to other resources referred to in the database, such as
                     publications and online resources.</p>
 
-                <p>TibSchol database does not contain metadata on natural persons.</p>
-
-                <p>Text excerpts (<span class="material-symbols-outlined">text_snippet</span>) are from works in the Public Domain.
-                    Related TEI files that contain these excerpts, hosted at <a
-                       target="_blank" href="https://github.com/ERC-TibSchol/TibSchol-TEI-Library">TibSchol-TEI-Library</a>,
-                    are distributed under a <a target="_blank" href="https://creativecommons.org/licenses/by-sa/4.0/">Creative Common CC BY-SA 4.0
-                    License</a>.    </p>
                         <p>
         For enquiries and comments, please write to: <a href="mailto:ERC.tibschol@oeaw.ac.at">ERC.tibschol@oeaw.ac.at</a>.
     </p>


### PR DESCRIPTION
addresses #644
This pull request updates the content of the `imprint.html` page to clarify licensing information and improve the guidance on citing database content. The changes focus on simplifying and updating the licensing statements, removing outdated or redundant details, and adding clearer instructions for citation.

Content and licensing updates:

* Updated the licensing section to clarify that text excerpts are from works in the Public Domain, and that related TEI files are distributed under the CC BY-SA 4.0 license, with a direct link to the relevant repository.
* Added instructions to cite information from Comments and Item descriptions using the URL and access date.
* Removed outdated or redundant information about data sources for persons, works, and places, as well as a statement about the absence of metadata on natural persons.