### PR TITLE
Relations listview filter

### DIFF
--- a/apis_ontology/filtersets.py
+++ b/apis_ontology/filtersets.py
@@ -124,6 +124,21 @@ class TibScholRelationMixinFilterSet(RelationFilterSet):
             FuzzyDateParserField: {"filter_class": YearIntervalRangeFilter},
         }
 
+
+    notes_or_refs = django_filters.CharFilter(
+        label="References contain",
+        method="filter_notes_or_refs"
+    )
+
+    def filter_notes_or_refs(self, queryset, name, value):
+        """Custom filter method to search across support_notes, tei_refs, and zotero_refs."""
+        query = (
+            models.Q(support_notes__icontains=value)
+            | models.Q(tei_refs__icontains=value)
+            | models.Q(zotero_refs__icontains=value)
+        )
+        return queryset.filter(query)
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.filters.pop("search", None)  # safely remove the search filter

--- a/apis_ontology/filtersets.py
+++ b/apis_ontology/filtersets.py
@@ -103,7 +103,11 @@ class LegacyStuffMixinFilterSet(AbstractEntityFilterSet):
 class TibScholRelationMixinFilterSet(RelationFilterSet):
     class Meta(RelationFilterSet.Meta):
         form = RelationSearchForm
-        exclude = RelationFilterSet.Meta.exclude + ABSTRACT_ENTITY_FILTERS_EXCLUDE
+        exclude = (
+            RelationFilterSet.Meta.exclude
+            + ABSTRACT_ENTITY_FILTERS_EXCLUDE
+            + ["support_notes", "tei_refs", "zotero_refs"]
+        )
         filter_overrides = {
             models.CharField: {
                 "filter_class": django_filters.CharFilter,
@@ -194,7 +198,6 @@ class PersonFilterSet(TibScholEntityMixinFilterSet):
             *ABSTRACT_ENTITY_FILTERS_EXCLUDE,
             "alternative_names",
             "tibetan_transliteration",
-            
         ]
         form = PersonSearchForm
 

--- a/apis_ontology/forms.py
+++ b/apis_ontology/forms.py
@@ -231,3 +231,13 @@ class RelationSearchForm(GenericFilterSetForm):
         "end_date_to",
         "relation_ptr",
     ]
+    field_order = [
+        "columns",
+        "subj_search",
+        "obj_search",
+        "confidence",
+        "notes_or_refs",
+        "start",
+        "end",
+        "..."
+    ]


### PR DESCRIPTION
This pull request enhances the filtering capabilities for relation entities in the `apis_ontology` app by introducing a new filter that allows users to search for references and notes across multiple fields. It also refines the filter form by updating the excluded fields and adjusting the field order for improved usability.

### Filtering enhancements

* Added a new `notes_or_refs` filter to `TibScholRelationMixinFilterSet`, enabling users to search across `support_notes`, `tei_refs`, and `zotero_refs` fields using a single input. This is implemented via a custom filter method `filter_notes_or_refs`.
* Updated the `exclude` list in the `Meta` class of `TibScholRelationMixinFilterSet` to ensure `support_notes`, `tei_refs`, and `zotero_refs` are excluded from the default filters, preventing redundancy with the new unified filter.

### Form improvements

* Modified the `field_order` in `RelationSearchForm` to include the new `notes_or_refs` filter, ensuring it appears in a logical position in the form UI.

### Minor cleanups

* Removed an unnecessary empty line in the `exclude` list of another filterset for consistency.