### PR TITLE
fix(templates): fix credit to BDRC

### DIFF
--- a/apis_ontology/templates/base.html
+++ b/apis_ontology/templates/base.html
@@ -215,8 +215,8 @@ TibSchol: The Dawn of Tibetan Buddhist Scholasticism (11th–13th c.)
                     alt="Epistemological works">
                 <figcaption class="figure-caption text-center">
                     Folio of Phywa pa chos kyi seng ge's Tshad ma yid kyi mun sel.<br>
-                    <small>© Buddhist Digital Resource Center, [<a href="purl.bdrc.io/resource/MW12171" target="_blank">bdr:MW12171</a>.
-                        Accessed 6 May 2026.]</small>
+                    <small>© Buddhist Digital Resource Center [<a href="purl.bdrc.io/resource/MW12171" target="_blank">BDRC bdr:MW12171</a>]
+                        Accessed 6 May 2026.</small>
                     </figcaption>
                     </figure>
                     </div>


### PR DESCRIPTION
This pull request makes a minor update to the attribution text in the `apis_ontology/templates/base.html` file to clarify the source citation for an image.

- Updated the image caption to clarify the source citation, changing the text to "© Buddhist Digital Resource Center [BDRC bdr:MW12171]" for improved attribution clarity.