### PR TITLE
fix(templates): uniform credits and caption for images

### DIFF
--- a/apis_ontology/templates/base.html
+++ b/apis_ontology/templates/base.html
@@ -233,9 +233,8 @@ TibSchol: The Dawn of Tibetan Buddhist Scholasticism (11th–13th c.)
                 alt="Abbots of gSang phu monastery">
             <figcaption class="figure-caption text-center">
                 Detail of Lhasa cityscape<br>
-                <small><a href="https://www.himalayanart.org/items/65848" target="_blank">Himalayan Art Resources #65848</a> Copyright ©
-                    2026 Himalayan Art Resources Inc. Photographed Image Copyright © 2004 Rubin Museum of
-                    Art</small>
+                <small>© 2026 Himalayan Art Resources Inc. Photographed Image © 2004 Rubin Museum of Art [<a
+                        href="https://www.himalayanart.org/items/65848" target="_blank">Himalayan Art Resources #65848</a>]</small>
                 </figcaption>
                 </figure>
                 </div>


### PR DESCRIPTION
This pull request makes a small update to the image caption in the `base.html` template. The change clarifies the copyright attribution and reorders the placement of the link for better readability.