### PR TITLE
feat(templates): replace IKGA link to the TibSchol project page at IKGA

### DIFF
--- a/apis_ontology/templates/base.html
+++ b/apis_ontology/templates/base.html
@@ -146,7 +146,8 @@ TibSchol: The Dawn of Tibetan Buddhist Scholasticism (11th–13th c.)
             Welcome to the database of TibSchol — “The Dawn of Tibetan Buddhist Scholasticism (11th–13th c.)” project (<a
                 href="https://doi.org/10.3030/101001002" target="_blank" rel="noopener noreferrer">DOI:10.3030/101001002</a>),
             funded by a Consolidator Grant of the European Research Council (2021–2026) and hosted at the <a
-                href="https://www.oeaw.ac.at/ikga" target="_blank" rel="noopener noreferrer">Institute for the Cultural and
+                href="https://www.oeaw.ac.at/ikga/forschung/tibetologie/laufende-drittmittelprojekte/tibschol-1" target="_blank"
+                rel="noopener noreferrer">Institute for the Cultural and
                 Intellectual History of Asia</a> at the <a href="https://www.oeaw.ac.at/" target="_blank"
                 rel="noopener noreferrer">Austrian Academy of Sciences</a>.
         </p>


### PR DESCRIPTION
This pull request makes a small update to the project homepage by changing the link for the "Institute for the Cultural and Intellectual History of Asia" to point to a more specific project page.

* Updated the URL for the Institute's link in `base.html` to direct users to the TibSchol project page instead of the general institute homepage.